### PR TITLE
Fix/downgrade required node to 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# IDEs
+.idea
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@semantic-release/npm": "10.0.3",
         "@semantic-release/release-notes-generator": "11.0.1",
         "@types/inputmask": "^5.0.3",
-        "@types/node": "18",
+        "@types/node": "16",
         "@types/react": ">=16.4 || ^17.0.0 || ^18.0.0",
         "@types/react-dom": ">=16.4 || ^17.0.0 || ^18.0.0",
         "@typescript-eslint/eslint-plugin": "5.59.2",
@@ -42,7 +42,7 @@
         "vitest": "^0.31.0"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=16",
         "npm": ">=7"
       },
       "peerDependencies": {
@@ -1720,9 +1720,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.7.22",
-      "dev": true,
-      "license": "MIT"
+      "version": "16.18.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.28.tgz",
+      "integrity": "sha512-SNMfiPqsiPoYfmyi+2qnDO4nZyMIOCab/CW+Slcml0lhIzkOizYzWtt/A7tgB3TSitd+YJKi8fSC2Cpm/VCp7A==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -12387,7 +12388,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.22",
+      "version": "16.18.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.28.tgz",
+      "integrity": "sha512-SNMfiPqsiPoYfmyi+2qnDO4nZyMIOCab/CW+Slcml0lhIzkOizYzWtt/A7tgB3TSitd+YJKi8fSC2Cpm/VCp7A==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "types": "./dist/index.d.ts"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=16",
     "npm": ">=7"
   },
   "scripts": {
@@ -44,7 +44,7 @@
     "@semantic-release/npm": "10.0.3",
     "@semantic-release/release-notes-generator": "11.0.1",
     "@types/inputmask": "^5.0.3",
-    "@types/node": "18",
+    "@types/node": "16",
     "@types/react": ">=16.4 || ^17.0.0 || ^18.0.0",
     "@types/react-dom": ">=16.4 || ^17.0.0 || ^18.0.0",
     "@typescript-eslint/eslint-plugin": "5.59.2",


### PR DESCRIPTION
Node 18 (Hydrogen) is fairly recent, so many applications still depend on Node 16.

![image](https://github.com/eduardoborges/use-mask-input/assets/15681333/037e16d7-d3d3-4286-b94c-594660982b90)

The bump from Node 10 was absolutely necessary, but 16 would potentially increase the adoption of the library.

`npm audit`
![image](https://github.com/eduardoborges/use-mask-input/assets/15681333/0e507de3-db2d-4cd0-830d-7b0eaed39589)

`build` | `lint` | `test`
![image](https://github.com/eduardoborges/use-mask-input/assets/15681333/759edf25-9509-45d1-bf4d-0da7024e1ea6)
