### PR TITLE
chore: remove misplaced test functions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,10 +18,3 @@ export const pipe = <T extends any[], R>(
 export const compose = <R>(
   fn1: (a: R) => R, ...fns: Array<(a: R) => R>
 ) => fns.reduce((prevFn, nextFn) => (value) => prevFn(nextFn(value)), fn1);
-
-const sum = compose(
-  (x: number) => x + 1,
-  (x: number) => x + 1,
-);
-
-console.log(sum(1));


### PR DESCRIPTION
I think this was used as a prototype and left behind accidentally. The test file [utils.spec.ts](https://github.com/eduardoborges/use-mask-input/blob/main/src/utils.spec.ts) has the same definition.