### PR TITLE
chore: change dependency type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "inputmask": "5.0.8",
-        "react-hook-form": "^7"
+        "inputmask": "5.0.8"
       },
       "devDependencies": {
         "@semantic-release/changelog": "6.0.3",
@@ -32,6 +31,7 @@
         "eslint-plugin-jsx-a11y": "6.7.1",
         "eslint-plugin-react": "7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "react-hook-form": "^7",
         "read-pkg": "^8.0.0",
         "rollup": "^3.21.4",
         "rollup-plugin-dts": "^5.3.0",
@@ -9374,6 +9374,7 @@
       "version": "7.43.9",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
       "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
+      "dev": true,
       "engines": {
         "node": ">=12.22.0"
       },
@@ -17517,6 +17518,7 @@
       "version": "7.43.9",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
       "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
+      "dev": true,
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "src"
   ],
   "dependencies": {
-    "inputmask": "5.0.8",
-    "react-hook-form": "^7"
+    "inputmask": "5.0.8"
   },
   "peerDependencies": {
     "react": ">=16.4 || ^17.0.0 || ^18.0.0",
@@ -56,6 +55,7 @@
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "react-hook-form": "^7",
     "read-pkg": "^8.0.0",
     "rollup": "^3.21.4",
     "rollup-plugin-dts": "^5.3.0",


### PR DESCRIPTION
Since `react-hook-form` is only used to import type definitions, it could be just a `devDependency`.

![image](https://github.com/eduardoborges/use-mask-input/assets/15681333/85b92389-ad19-4fa8-a357-b35aca435417)
