### PR TITLE
fix: prepare withMask function to React 19 ref breaking changes

### DIFF
--- a/src/withMask.ts
+++ b/src/withMask.ts
@@ -4,14 +4,12 @@ import { Input, Mask, Options } from './types';
 
 export const withMask = (mask: Mask, options?: Options) => (input: Input) => {
   //
-  if (isServer) return input;
-  if (mask === null) return input;
+  if (isServer) return;
+  if (mask === null) return;
 
   const maskInput = Inputmask(getMaskOptions(mask, options));
 
   if (input) {
     maskInput.mask(input);
   }
-
-  return input;
 };


### PR DESCRIPTION
I updated the withMask function in order to prepare it to the upcoming React 19 breaking changes on refs.
More info on https://react.dev/blog/2024/04/25/react-19#cleanup-functions-for-refs.