### PR TITLE
fix: bump inputmask version to a working version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-jsx-a11y": "6.7.1",
         "eslint-plugin-react": "7.33.2",
         "eslint-plugin-react-hooks": "4.6.0",
-        "inputmask": "5.0.9-beta.32",
+        "inputmask": "5.0.10-beta.11",
         "patch-package": "^8.0.0",
         "react-hook-form": "7.47.0",
         "read-pkg": "8.1.0",
@@ -4377,9 +4377,9 @@
       "license": "ISC"
     },
     "node_modules/inputmask": {
-      "version": "5.0.9-beta.32",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9-beta.32.tgz",
-      "integrity": "sha512-X4WxSCPTaLAnuVDyEt2WLa9mP56OQpZgJSg0YEPrmy7HMGxlbCr4tkut7TbPO+nSBDF1RXK603ZxB6bWLsS9uQ==",
+      "version": "5.0.10-beta.11",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.10-beta.11.tgz",
+      "integrity": "sha512-+tBe7fbGfOmf2frDhhxJHeeBQ4Na00cEl23ie7G+O0TMtFnQDhJYTFnWKi9EdzqaEEG7R82tI5JRr8Ngzbd1RQ==",
       "dev": true
     },
     "node_modules/internal-slot": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-jsx-a11y": "6.7.1",
         "eslint-plugin-react": "7.33.2",
         "eslint-plugin-react-hooks": "4.6.0",
-        "inputmask": "5.0.10-beta.11",
+        "inputmask": "^5.0.10-beta.10",
         "patch-package": "^8.0.0",
         "react-hook-form": "7.47.0",
         "read-pkg": "8.1.0",
@@ -4377,9 +4377,9 @@
       "license": "ISC"
     },
     "node_modules/inputmask": {
-      "version": "5.0.10-beta.11",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.10-beta.11.tgz",
-      "integrity": "sha512-+tBe7fbGfOmf2frDhhxJHeeBQ4Na00cEl23ie7G+O0TMtFnQDhJYTFnWKi9EdzqaEEG7R82tI5JRr8Ngzbd1RQ==",
+      "version": "5.0.10-beta.10",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.10-beta.10.tgz",
+      "integrity": "sha512-31iKmbjC+uI33LqmJaqyoOWqBKX5by0+aizvPOxv3A0fXbrY3sQlvVGcKTxueniQyJcYJIY6N9a26rSNl0S+3g==",
       "dev": true
     },
     "node_modules/internal-slot": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=16.4 || 17 || 18 || 20"
   },
   "devDependencies": {
-    "inputmask": "5.0.10-beta.9",
+    "inputmask": "5.0.10-beta.11",
     "@rollup/plugin-commonjs": "25.0.7",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@semantic-release/changelog": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react-dom": ">=16.4 || 17 || 18 || 20"
   },
   "devDependencies": {
-    "inputmask": "5.0.10-beta.11",
     "@rollup/plugin-commonjs": "25.0.7",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@semantic-release/changelog": "6.0.3",
@@ -60,6 +59,7 @@
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-react": "7.33.2",
     "eslint-plugin-react-hooks": "4.6.0",
+    "inputmask": "^5.0.10-beta.10",
     "patch-package": "^8.0.0",
     "react-hook-form": "7.47.0",
     "read-pkg": "8.1.0",


### PR DESCRIPTION
The current inputmask version is breaking the `npm install`.