### PR TITLE
refactor(useInputMask): remove unnecessary isServer check

### DIFF
--- a/src/useMaskInput.ts
+++ b/src/useMaskInput.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import inputmask from 'inputmask';
-import { getMaskOptions, isServer } from './utils';
+import { getMaskOptions } from './utils';
 import { Mask, Options } from './types';
 
 interface UseInputMaskOptions {

--- a/src/useMaskInput.ts
+++ b/src/useMaskInput.ts
@@ -12,19 +12,16 @@ interface UseInputMaskOptions {
 export const useInputMask = (props: UseInputMaskOptions) => {
   const { mask, register, options } = props;
   const ref = useRef<HTMLInputElement>(null);
-  if (isServer) return ref;
 
   useEffect(() => {
-    if (!isServer) {
-      if (!ref.current) return;
+    if (!ref.current) return;
 
-      const maskInput = inputmask(getMaskOptions(mask, options));
+    const maskInput = inputmask(getMaskOptions(mask, options));
 
-      maskInput.mask(ref.current);
+    maskInput.mask(ref.current);
 
-      if (register && ref.current) {
-        register(ref.current);
-      }
+    if (register && ref.current) {
+      register(ref.current);
     }
   }, [mask, register, options]);
 


### PR DESCRIPTION
Removed the isServer check from the useInputMask hook. Since React's useEffect hook does not run during server-side rendering (SSR), this check was redundant. This change simplifies the code without affecting its functionality.