### PR TITLE
fix: use Inputmask ESM modules

### DIFF
--- a/.changeset/modern-inputmask-imports.md
+++ b/.changeset/modern-inputmask-imports.md
@@ -2,4 +2,8 @@
 "use-mask-input": patch
 ---
 
-Import Inputmask from its ESM source modules to avoid bundling legacy UMD polyfills in the published build.
+Import Inputmask from its ESM source modules instead of the default UMD entrypoint. This keeps the existing APIs and bundled dependency behavior while avoiding the legacy Inputmask build in published artifacts.
+
+In a Next.js reproduction using `use-mask-input/antd`, the Inputmask client chunk dropped from 125.13 kB to 92.84 kB raw, 36.75 kB to 28.89 kB gzip, and 31.86 kB to 25.91 kB brotli. That is a final reduction of 32.29 kB raw, 7.86 kB gzip, and 5.96 kB brotli for the affected client chunk.
+
+The modern build no longer includes the legacy UMD/polyfill patterns reported by Lighthouse, including `String.prototype.includes`, `Array.prototype.includes`, `Object.entries =`, `Cannot call a class as a function`, and `inputmask/dist/inputmask.js`.

--- a/.changeset/modern-inputmask-imports.md
+++ b/.changeset/modern-inputmask-imports.md
@@ -1,0 +1,5 @@
+---
+"use-mask-input": patch
+---
+
+Import Inputmask from its ESM source modules to avoid bundling legacy UMD polyfills in the published build.

--- a/packages/use-mask-input/src/antd/useMaskInputAntd.spec.tsx
+++ b/packages/use-mask-input/src/antd/useMaskInputAntd.spec.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import inputmask from 'inputmask';
+import inputmask from '../core/inputmask';
 import {
   beforeEach,
   describe,
@@ -12,7 +12,7 @@ import useMaskInputAntd from './useMaskInputAntd';
 
 import type { InputRef } from 'antd';
 
-vi.mock('inputmask', () => ({
+vi.mock('../core/inputmask', () => ({
   default: vi.fn((options) => ({
     mask: vi.fn(),
     options,

--- a/packages/use-mask-input/src/api/useHookFormMask.spec.ts
+++ b/packages/use-mask-input/src/api/useHookFormMask.spec.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import inputmask from 'inputmask';
+import inputmask from '../core/inputmask';
 import {
   beforeEach,
   describe, expect, it, vi,
@@ -9,7 +9,7 @@ import useHookFormMask from './useHookFormMask';
 
 import type { FieldValues, UseFormRegister } from 'react-hook-form';
 
-vi.mock('inputmask', () => ({
+vi.mock('../core/inputmask', () => ({
   default: vi.fn((options) => ({
     mask: vi.fn(),
     options,

--- a/packages/use-mask-input/src/api/useMaskInput.spec.tsx
+++ b/packages/use-mask-input/src/api/useMaskInput.spec.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import inputmask from 'inputmask';
+import inputmask from '../core/inputmask';
 import {
   beforeEach,
   describe, expect, it, vi,
@@ -10,7 +10,7 @@ import * as core from '../core';
 
 import type { Input } from '../types';
 
-vi.mock('inputmask', () => ({
+vi.mock('../core/inputmask', () => ({
   default: vi.fn((options) => ({
     mask: vi.fn(),
     options,

--- a/packages/use-mask-input/src/api/withHookFormMask.spec.ts
+++ b/packages/use-mask-input/src/api/withHookFormMask.spec.ts
@@ -1,4 +1,4 @@
-import inputmask from 'inputmask';
+import inputmask from '../core/inputmask';
 import {
   beforeEach,
   describe, expect, it, vi,
@@ -11,7 +11,7 @@ import type { FieldValues } from 'react-hook-form';
 
 import type { UseHookFormMaskReturn } from '../types';
 
-vi.mock('inputmask', () => ({
+vi.mock('../core/inputmask', () => ({
   default: vi.fn((options) => ({
     mask: vi.fn(),
     options,

--- a/packages/use-mask-input/src/api/withMask.spec.ts
+++ b/packages/use-mask-input/src/api/withMask.spec.ts
@@ -1,11 +1,11 @@
-import inputmask from 'inputmask';
+import inputmask from '../core/inputmask';
 import {
   beforeEach, describe, expect, it, vi,
 } from 'vitest';
 
 import withMask from './withMask';
 
-vi.mock('inputmask', () => ({
+vi.mock('../core/inputmask', () => ({
   default: vi.fn((options) => ({
     mask: vi.fn(),
     options,

--- a/packages/use-mask-input/src/api/withMask.ts
+++ b/packages/use-mask-input/src/api/withMask.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import-x/no-extraneous-dependencies */
-import inputmask from 'inputmask';
+import inputmask from '../core/inputmask';
 
 import { getMaskOptions } from '../core/maskConfig';
 import { getUnmaskedValue, makeMaskCacheKey, setUnmaskedValue } from '../utils';

--- a/packages/use-mask-input/src/api/withTanStackFormMask.spec.ts
+++ b/packages/use-mask-input/src/api/withTanStackFormMask.spec.ts
@@ -1,4 +1,4 @@
-import inputmask from 'inputmask';
+import inputmask from '../core/inputmask';
 import {
   beforeEach,
   describe, expect, it, vi,
@@ -8,7 +8,7 @@ import withTanStackFormMask from './withTanStackFormMask';
 
 import type { TanStackFormInputProps } from '../types';
 
-vi.mock('inputmask', () => ({
+vi.mock('../core/inputmask', () => ({
   default: vi.fn((options) => ({
     mask: vi.fn(),
     options,

--- a/packages/use-mask-input/src/core/inputmask.spec.ts
+++ b/packages/use-mask-input/src/core/inputmask.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import inputmask from './inputmask';
+
+describe('inputmask wrapper', () => {
+  it('loads the aliases used by built-in masks', () => {
+    const aliases = (inputmask as unknown as { prototype: { aliases: Record<string, unknown> } }).prototype.aliases;
+
+    expect(aliases.datetime).toBeDefined();
+    expect(aliases.email).toBeDefined();
+    expect(aliases.numeric).toBeDefined();
+    expect(aliases.currency).toBeDefined();
+    expect(aliases.decimal).toBeDefined();
+    expect(aliases.integer).toBeDefined();
+    expect(aliases.percentage).toBeDefined();
+    expect(aliases.url).toBeDefined();
+    expect(aliases.ip).toBeDefined();
+    expect(aliases.mac).toBeDefined();
+    expect(aliases.ssn).toBeDefined();
+  });
+});

--- a/packages/use-mask-input/src/core/inputmask.ts
+++ b/packages/use-mask-input/src/core/inputmask.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import-x/no-extraneous-dependencies, import/no-unassigned-import */
+import Inputmask from 'inputmask/lib/inputmask.js';
+
+import 'inputmask/lib/extensions/inputmask.extensions.js';
+import 'inputmask/lib/extensions/inputmask.date.extensions.js';
+import 'inputmask/lib/extensions/inputmask.numeric.extensions.js';
+
+export default Inputmask;

--- a/packages/use-mask-input/src/core/inputmask.ts
+++ b/packages/use-mask-input/src/core/inputmask.ts
@@ -1,4 +1,6 @@
 /* eslint-disable import-x/no-extraneous-dependencies, import/no-unassigned-import */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore Inputmask exposes this ESM file but not its subpath types in app builds.
 import Inputmask from 'inputmask/lib/inputmask.js';
 
 import 'inputmask/lib/extensions/inputmask.extensions.js';

--- a/packages/use-mask-input/src/core/maskEngine.spec.ts
+++ b/packages/use-mask-input/src/core/maskEngine.spec.ts
@@ -1,4 +1,4 @@
-import inputmask from 'inputmask';
+import inputmask from './inputmask';
 import {
   beforeEach, describe, expect, it, vi,
 } from 'vitest';
@@ -11,7 +11,7 @@ function stubMaskInstance(maskFn: ReturnType<typeof vi.fn>): MaskInstance {
   return { mask: maskFn } as unknown as MaskInstance;
 }
 
-vi.mock('inputmask', () => ({
+vi.mock('./inputmask', () => ({
   default: vi.fn((options) => ({
     mask: vi.fn(),
     options,

--- a/packages/use-mask-input/src/core/maskEngine.ts
+++ b/packages/use-mask-input/src/core/maskEngine.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import-x/no-extraneous-dependencies */
-import inputmask from 'inputmask';
+import inputmask from './inputmask';
 
 import { getMaskOptions } from './maskConfig';
 import { moduleInterop } from '../utils';

--- a/packages/use-mask-input/src/core/maskEngine.ts
+++ b/packages/use-mask-input/src/core/maskEngine.ts
@@ -14,7 +14,7 @@ import type { Mask, Options } from '../types';
  * @param options - Optional configuration options
  * @returns A mask instance
  */
-export function createMaskInstance(mask: Mask, options?: Options): Inputmask.Instance {
+export function createMaskInstance(mask: Mask, options?: Options): ReturnType<typeof inputmask> {
   const inputmaskInstance = moduleInterop(inputmask);
   return inputmaskInstance(getMaskOptions(mask, options));
 }

--- a/packages/use-mask-input/src/types/inputmask-modules.d.ts
+++ b/packages/use-mask-input/src/types/inputmask-modules.d.ts
@@ -1,9 +1,0 @@
-declare module 'inputmask/lib/inputmask.js' {
-  import Inputmask from 'inputmask';
-
-  export default Inputmask;
-}
-
-declare module 'inputmask/lib/extensions/inputmask.extensions.js';
-declare module 'inputmask/lib/extensions/inputmask.date.extensions.js';
-declare module 'inputmask/lib/extensions/inputmask.numeric.extensions.js';

--- a/packages/use-mask-input/src/types/inputmask-modules.d.ts
+++ b/packages/use-mask-input/src/types/inputmask-modules.d.ts
@@ -1,0 +1,9 @@
+declare module 'inputmask/lib/inputmask.js' {
+  import Inputmask from 'inputmask';
+
+  export default Inputmask;
+}
+
+declare module 'inputmask/lib/extensions/inputmask.extensions.js';
+declare module 'inputmask/lib/extensions/inputmask.date.extensions.js';
+declare module 'inputmask/lib/extensions/inputmask.numeric.extensions.js';

--- a/packages/use-mask-input/src/utils/maskHelpers.ts
+++ b/packages/use-mask-input/src/utils/maskHelpers.ts
@@ -2,6 +2,10 @@ import { findInputElement, resolveInputRef } from '../core/elementResolver';
 
 import type { Input, Mask, UnmaskedValueApi } from '../types';
 
+type MaskedElement = (HTMLInputElement | HTMLTextAreaElement) & {
+  inputmask?: { unmaskedvalue?: () => string };
+};
+
 /**
  * Builds a stable string key from a field name and mask, used to cache ref
  * callbacks so their identity stays stable across renders.
@@ -39,9 +43,7 @@ export function getUnmaskedValue(input: Input | null): string {
   const element = resolveUnmaskedInput(input);
   if (!element) return '';
 
-  const inputmask = (element as HTMLInputElement).inputmask as
-    | { unmaskedvalue?: () => string }
-    | undefined;
+  const { inputmask } = element as MaskedElement;
 
   if (inputmask && typeof inputmask.unmaskedvalue === 'function') {
     return inputmask.unmaskedvalue();


### PR DESCRIPTION
## Summary
- Import Inputmask from its ESM source modules instead of the default UMD entrypoint.
- Keep the public API and bundled Inputmask dependency unchanged.
- Add wrapper coverage to ensure the built-in alias modules still load.

Fixes #175.

## Bundle Report
Measured with two temporary worktrees: a clean baseline from `HEAD` before this change and the patched branch.

### Library dist
| Artifact | Before | After | Delta |
| --- | ---: | ---: | ---: |
| ESM shared chunk raw | 225.75 kB | 219.55 kB | -6.21 kB (**-2.75%**) |
| ESM shared chunk gzip | 49.20 kB | 46.08 kB | -3.12 kB (**-6.34%**) |
| ESM shared chunk brotli | 39.80 kB | 39.20 kB | -0.61 kB (**-1.53%**) |
| Total JS/CJS raw | 467.78 kB | 455.37 kB | -12.41 kB (**-2.65%**) |
| Total JS/CJS gzip | 102.80 kB | 96.56 kB | -6.24 kB (**-6.07%**) |
| Total JS/CJS brotli | 83.59 kB | 82.34 kB | -1.25 kB (**-1.49%**) |

### Next.js reproduction
The reproduction imported `useMaskInputAntd` from `use-mask-input/antd` and consumed the built package from `dist`, not the local source alias.

| Artifact | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Inputmask chunk raw | 125.13 kB | 92.84 kB | -32.29 kB (**-25.80%**) |
| Inputmask chunk gzip | 36.75 kB | 28.89 kB | -7.86 kB (**-21.39%**) |
| Inputmask chunk brotli | 31.86 kB | 25.91 kB | -5.96 kB (**-18.69%**) |
| Total `.next/static/chunks` raw | 751.26 kB | 718.97 kB | -32.29 kB (**-4.30%**) |
| Total `.next/static/chunks` gzip | 221.69 kB | 213.83 kB | -7.86 kB (**-3.55%**) |
| Total `.next/static/chunks` brotli | 191.41 kB | 185.46 kB | -5.96 kB (**-3.11%**) |

## Legacy JavaScript Check
The legacy/polyfill patterns reported in the issue are gone from the Next.js reproduction chunks.

| Pattern | Before | After |
| --- | ---: | ---: |
| `String.prototype.includes` | 2 | 0 |
| `Array.prototype.includes` | 1 | 0 |
| `Object.entries =` | 1 | 0 |
| `Cannot call a class as a function` | 3 | 0 |
| `inputmask/dist/inputmask.js` | 1 | 0 |

Generic `Object.entries(...)` calls still exist because Next.js and the ESM Inputmask source use the native API directly, but the polyfill assignment is no longer bundled.

## Verification
- `pnpm --filter use-mask-input build`
- `pnpm --filter use-mask-input test`
- `pnpm --filter use-mask-input type-check`
- `pnpm --filter use-mask-input lint`
- Temporary Next.js 16 production build for the `use-mask-input/antd` reproduction