### PR TITLE
fix: add npm license metadata

### DIFF
--- a/.changeset/silver-shirts-arrive.md
+++ b/.changeset/silver-shirts-arrive.md
@@ -1,0 +1,5 @@
+---
+"use-mask-input": patch
+---
+
+Add npm license metadata to the package manifest.

--- a/packages/use-mask-input/package.json
+++ b/packages/use-mask-input/package.json
@@ -3,6 +3,7 @@
   "version": "3.10.1",
   "private": false,
   "description": "A react Hook for build elegant input masks. Compatible with React Hook Form",
+  "license": "MIT",
   "author": "Eduardo Borges<euduardoborges@gmail.com>",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- Add npm license metadata to the published `use-mask-input` package manifest.
- Use `MIT`, matching the repository LICENSE.

## Validation
- `node -e "const p=require('./packages/use-mask-input/package.json'); if(p.name!=='use-mask-input') throw new Error('wrong package'); if(p.license!=='MIT') throw new Error('missing MIT'); console.log(JSON.stringify({name:p.name,version:p.version,license:p.license}))"`
- `git diff --check`
- `npm pack --dry-run --json --ignore-scripts ./packages/use-mask-input`