### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/use-mask-input/package.json
+++ b/packages/use-mask-input/package.json
@@ -1,6 +1,9 @@
 {
   "name": "use-mask-input",
   "version": "3.10.2",
+  "bugs": {
+    "url": "https://github.com/eduardoborges/use-mask-input/issues"
+  },
   "private": false,
   "description": "A react Hook for build elegant input masks. Compatible with React Hook Form",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/use-mask-input/package.json`.

Fixes npm tooling unable to resolve package metadata.