### PR TITLE
fix(types): allow TanStack Form onChange/onBlur to target textarea elements

### DIFF
--- a/.changeset/tanstack-textarea-onchange-type.md
+++ b/.changeset/tanstack-textarea-onchange-type.md
@@ -1,0 +1,7 @@
+---
+"use-mask-input": patch
+---
+
+Widen `TanStackFormInputProps.onChange`/`onBlur` to accept `HTMLTextAreaElement` in addition to `HTMLInputElement`.
+
+`use-mask-input` supports masking `<textarea>` elements, but #184 pinned the TanStack Form `onChange`/`onBlur` event types to `ChangeEvent<HTMLInputElement>`/`FocusEvent<HTMLInputElement>` only. That broke consumers masking a `<textarea>` field who explicitly annotate their handler as `ChangeEvent<HTMLTextAreaElement>`, and mistyped the event for anyone relying on inline (unannotated) handlers rendering a `<textarea>`. The event types are now `ChangeEvent<HTMLInputElement | HTMLTextAreaElement>` / `FocusEvent<HTMLInputElement | HTMLTextAreaElement>`.

--- a/packages/use-mask-input/src/api/useTanStackFormMask.spec.ts
+++ b/packages/use-mask-input/src/api/useTanStackFormMask.spec.ts
@@ -7,6 +7,7 @@ import {
 
 import useTanStackFormMask from './useTanStackFormMask';
 
+import type { ChangeEvent } from 'react';
 import type { TanStackFormInputProps } from '../types';
 
 vi.mock('../core/inputmask', () => ({
@@ -102,5 +103,49 @@ describe('useTanStackFormMask', () => {
     masked.onChange?.({ target: input } as never);
 
     expect(handleChange).toHaveBeenCalledWith('12345');
+  });
+
+  it('infers the onChange event type for a masked textarea field', () => {
+    const { result } = renderHook(() => useTanStackFormMask());
+    const handleChange = vi.fn();
+
+    // use-mask-input also supports masking <textarea> elements. The inline
+    // `event` parameter must infer a type whose `.target` covers
+    // HTMLTextAreaElement, not be pinned to HTMLInputElement only.
+    const masked = result.current('999-999', {
+      name: 'notes',
+      value: '',
+      onBlur: vi.fn(),
+      onChange: (event) => handleChange(event.target.value),
+    });
+
+    const textarea = document.createElement('textarea');
+    textarea.value = 'hello';
+    masked.onChange?.({ target: textarea } as never);
+
+    expect(handleChange).toHaveBeenCalledWith('hello');
+  });
+
+  it('accepts a handler explicitly typed for HTMLInputElement-only members', () => {
+    const { result } = renderHook(() => useTanStackFormMask());
+    const handleFiles = vi.fn();
+
+    // A handler narrowly annotated as ChangeEvent<HTMLInputElement> (reading an
+    // input-only member like `.files`) must still be assignable to onChange.
+    const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+      handleFiles(event.target.files);
+    };
+
+    const masked = result.current('cpf', {
+      name: 'cpf',
+      value: '',
+      onBlur: vi.fn(),
+      onChange,
+    });
+
+    const input = document.createElement('input');
+    masked.onChange?.({ target: input } as never);
+
+    expect(handleFiles).toHaveBeenCalledWith(input.files);
   });
 });

--- a/packages/use-mask-input/src/types/index.ts
+++ b/packages/use-mask-input/src/types/index.ts
@@ -47,8 +47,12 @@ export interface TanStackFormInputProps {
   name?: string;
   value?: string | number | readonly string[];
   ref?: RefCallback<HTMLElement | null>;
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
-  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
+  // Method shorthand (not an arrow-typed property) so the parameter is checked
+  // bivariantly: handlers explicitly typed for just HTMLInputElement (e.g. using
+  // `event.target.files`) or just HTMLTextAreaElement (e.g. `event.target.cols`)
+  // both remain assignable, alongside the common inline, unannotated handler.
+  onChange?(event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>): void;
+  onBlur?(event: FocusEvent<HTMLInputElement | HTMLTextAreaElement>): void;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #184. That PR fixed #183 (implicit `any` on the TanStack Form `onChange` event) by pinning `TanStackFormInputProps.onChange`/`onBlur` to `ChangeEvent<HTMLInputElement>`/`FocusEvent<HTMLInputElement>`.

`use-mask-input` also supports masking `<textarea>` elements (see `maskHelpers.ts`, which handles `HTMLInputElement | HTMLTextAreaElement` throughout). Pinning the event type to `HTMLInputElement` only mistyped the inline `event` parameter for anyone masking a `<textarea>` field, and broke consumers who explicitly annotate their handler for either element type.

### Fix

`onChange`/`onBlur` are now declared with method shorthand syntax and widened to `ChangeEvent<HTMLInputElement | HTMLTextAreaElement>` / `FocusEvent<HTMLInputElement | HTMLTextAreaElement>`. Method shorthand makes the parameter checked bivariantly, so:

- the common inline, unannotated handler (`onChange: (event) => field.handleChange(event.target.value)`) infers correctly for both input and textarea fields,
- a handler explicitly annotated `ChangeEvent<HTMLInputElement>` (e.g. reading `event.target.files`) stays assignable, and
- a handler explicitly annotated `ChangeEvent<HTMLTextAreaElement>` (e.g. reading `event.target.cols`) also stays assignable.

(An earlier revision of this PR used a plain union type instead of method shorthand, which broke the input-only case — thanks to @chatgpt-codex-connector for catching that in review.)

## Tests

- New `useTanStackFormMask` tests covering: a masked `<textarea>` field with an inline handler, and a handler explicitly typed for `HTMLInputElement`-only members (`.files`).

## Verification

- `tsc --noEmit`: clean
- Tests: 167 passing (was 165 on `main`)
- Lint + build: green
- Verified in a standalone project outside the monorepo (packed the built package with `npm pack`, installed via `file:`) that the original #183 repro, a masked textarea field, and an explicitly-typed input-only handler all type-check correctly.

A changeset (`patch`) is included.
