### PR TITLE
feat: expose formatWithMask and unformatWithMask utility functions

### DIFF
--- a/.changeset/expose-format-unformat.md
+++ b/.changeset/expose-format-unformat.md
@@ -1,0 +1,5 @@
+---
+'use-mask-input': minor
+---
+
+Expose `formatWithMask` and `unformatWithMask` utility functions for formatting and sanitizing values outside of a mounted element, useful for preparing data for the backend or displaying already-persisted values in the UI.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ function EmailInput() {
 | `withTanStackFormMask` | Function. Mask for TanStack input props. Requires `React.memo`. |
 | `useMaskInputAntd` | Hook. `useMaskInput` for Ant Design. |
 | `useHookFormMaskAntd` | Hook. `useHookFormMask` for Ant Design. |
+| `formatWithMask` | Function. Formats a raw value using a mask, without a mounted element. |
+| `unformatWithMask` | Function. Removes the mask from a formatted value, without a mounted element. |
 
 ## Built-in Aliases
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # API Reference
 
-**use-mask-input** exports six main APIs and two Ant Design-specific hooks. Choose the one that fits your use case:
+**use-mask-input** exports six main APIs, two Ant Design-specific hooks, and two standalone formatting utilities. Choose the one that fits your use case:
 
 | API | Type | React Hook Form | Ant Design | Needs `memo`? |
 |-----|------|:---------------:|:----------:|:-------------:|
@@ -16,6 +16,8 @@ sidebar_position: 2
 | [`withTanStackFormMask`](#withtanstackformmask) | Function | - | - | **Yes** |
 | [`useMaskInputAntd`](#usemaskinputantd) | Hook | - | Yes | No |
 | [`useHookFormMaskAntd`](#usehookformmaskantd) | Hook | Yes | Yes | No |
+| [`formatWithMask`](#formatwithmask) | Function | - | - | No |
+| [`unformatWithMask`](#unformatwithmask) | Function | - | - | No |
 
 ---
 
@@ -450,6 +452,79 @@ function MyForm() {
     </form>
   );
 }
+```
+
+---
+
+## Utilities
+
+`formatWithMask` and `unformatWithMask` work directly on plain values, with no DOM element required. Use them to format data for display (e.g. rendering a persisted value) or to sanitize data before sending it to the backend.
+
+### formatWithMask
+
+Formats a raw value using the given mask.
+
+```ts
+function formatWithMask(
+  value: string,
+  mask: Mask,
+  options?: Options
+): string
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|:--------:|-------------|
+| `value` | `string` | Yes | The raw value to format. |
+| `mask` | `Mask` | Yes | The mask pattern or alias. |
+| `options` | `Options` | No | Inputmask configuration options. |
+
+**Returns**
+
+The formatted (masked) value.
+
+**Example**
+
+```ts
+import { formatWithMask } from 'use-mask-input';
+
+formatWithMask('12345678900', 'cpf'); // '123.456.789-00'
+formatWithMask('999999', '999-999'); // '999-999'
+```
+
+---
+
+### unformatWithMask
+
+Removes the mask from a formatted value, returning the raw underlying value.
+
+```ts
+function unformatWithMask(
+  value: string,
+  mask: Mask,
+  options?: Options
+): string
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|:--------:|-------------|
+| `value` | `string` | Yes | The masked value to unformat. |
+| `mask` | `Mask` | Yes | The mask pattern or alias. |
+| `options` | `Options` | No | Inputmask configuration options. |
+
+**Returns**
+
+The raw, unmasked value.
+
+**Example**
+
+```ts
+import { unformatWithMask } from 'use-mask-input';
+
+unformatWithMask('123.456.789-00', 'cpf'); // '12345678900'
 ```
 
 ---

--- a/packages/use-mask-input/README.md
+++ b/packages/use-mask-input/README.md
@@ -120,6 +120,8 @@ function EmailInput() {
 | `withTanStackFormMask` | Function. Mask for TanStack input props. Requires `React.memo`. |
 | `useMaskInputAntd` | Hook. `useMaskInput` for Ant Design. |
 | `useHookFormMaskAntd` | Hook. `useHookFormMask` for Ant Design. |
+| `formatWithMask` | Function. Formats a raw value using a mask, without a mounted element. |
+| `unformatWithMask` | Function. Removes the mask from a formatted value, without a mounted element. |
 
 ## Built-in Aliases
 

--- a/packages/use-mask-input/src/core/maskEngine.spec.ts
+++ b/packages/use-mask-input/src/core/maskEngine.spec.ts
@@ -3,7 +3,9 @@ import {
   beforeEach, describe, expect, it, vi,
 } from 'vitest';
 
-import { applyMaskToElement, createMaskInstance } from './maskEngine';
+import {
+  applyMaskToElement, createMaskInstance, formatWithMask, unformatWithMask,
+} from './maskEngine';
 
 type MaskInstance = ReturnType<typeof createMaskInstance>;
 
@@ -11,12 +13,13 @@ function stubMaskInstance(maskFn: ReturnType<typeof vi.fn>): MaskInstance {
   return { mask: maskFn } as unknown as MaskInstance;
 }
 
-vi.mock('./inputmask', () => ({
-  default: vi.fn((options) => ({
+vi.mock('./inputmask', () => {
+  const mockInputmask = vi.fn((options) => ({
     mask: vi.fn(),
     options,
-  })),
-}));
+  }));
+  return { default: Object.assign(mockInputmask, { format: vi.fn(), unmask: vi.fn() }) };
+});
 
 describe('maskEngine', () => {
   beforeEach(() => {
@@ -109,6 +112,68 @@ describe('maskEngine', () => {
       applyMaskToElement(input, '999-999', { placeholder: '_' });
 
       expect(maskFn).toHaveBeenCalledWith(input);
+    });
+  });
+
+  describe('formatWithMask', () => {
+    it('formats a raw value using the given mask', () => {
+      const formatFn = vi.fn().mockReturnValue('999-999');
+      vi.mocked(inputmask).format = formatFn;
+
+      const result = formatWithMask('999999', '999-999');
+
+      expect(formatFn).toHaveBeenCalledWith('999999', expect.objectContaining({ mask: '999-999' }));
+      expect(result).toBe('999-999');
+    });
+
+    it('formats a raw value using an alias', () => {
+      const formatFn = vi.fn().mockReturnValue('123.456.789-00');
+      vi.mocked(inputmask).format = formatFn;
+
+      const result = formatWithMask('12345678900', 'cpf');
+
+      expect(formatFn).toHaveBeenCalledWith(
+        '12345678900',
+        expect.objectContaining({ mask: '999.999.999-99' }),
+      );
+      expect(result).toBe('123.456.789-00');
+    });
+
+    it('formats a raw value with custom options', () => {
+      const formatFn = vi.fn().mockReturnValue('999-999');
+      vi.mocked(inputmask).format = formatFn;
+
+      formatWithMask('999999', '999-999', { placeholder: '_' });
+
+      expect(formatFn).toHaveBeenCalledWith(
+        '999999',
+        expect.objectContaining({ mask: '999-999', placeholder: '_' }),
+      );
+    });
+  });
+
+  describe('unformatWithMask', () => {
+    it('unformats a masked value using the given mask', () => {
+      const unmaskFn = vi.fn().mockReturnValue('999999');
+      vi.mocked(inputmask).unmask = unmaskFn;
+
+      const result = unformatWithMask('999-999', '999-999');
+
+      expect(unmaskFn).toHaveBeenCalledWith('999-999', expect.objectContaining({ mask: '999-999' }));
+      expect(result).toBe('999999');
+    });
+
+    it('unformats a masked value using an alias', () => {
+      const unmaskFn = vi.fn().mockReturnValue('12345678900');
+      vi.mocked(inputmask).unmask = unmaskFn;
+
+      const result = unformatWithMask('123.456.789-00', 'cpf');
+
+      expect(unmaskFn).toHaveBeenCalledWith(
+        '123.456.789-00',
+        expect.objectContaining({ mask: '999.999.999-99' }),
+      );
+      expect(result).toBe('12345678900');
     });
   });
 });

--- a/packages/use-mask-input/src/core/maskEngine.ts
+++ b/packages/use-mask-input/src/core/maskEngine.ts
@@ -45,3 +45,31 @@ export function applyMaskToElement(
     maskInstance.mask(element);
   }
 }
+
+/**
+ * Formats a raw value using the given mask, without needing a mounted element.
+ * Useful for displaying already-persisted (unmasked) values in the UI.
+ *
+ * @param value - The raw value to format
+ * @param mask - The mask pattern
+ * @param options - Optional configuration options
+ * @returns The masked value
+ */
+export function formatWithMask(value: string, mask: Mask, options?: Options): string {
+  const inputmaskInstance = moduleInterop(inputmask);
+  return inputmaskInstance.format(value, getMaskOptions(mask, options));
+}
+
+/**
+ * Removes the mask from a formatted value, without needing a mounted element.
+ * Useful for sanitizing input before sending it to the backend.
+ *
+ * @param value - The masked value to unformat
+ * @param mask - The mask pattern
+ * @param options - Optional configuration options
+ * @returns The raw, unmasked value
+ */
+export function unformatWithMask(value: string, mask: Mask, options?: Options): string {
+  const inputmaskInstance = moduleInterop(inputmask);
+  return inputmaskInstance.unmask(value, getMaskOptions(mask, options));
+}

--- a/packages/use-mask-input/src/index.tsx
+++ b/packages/use-mask-input/src/index.tsx
@@ -7,6 +7,8 @@ export {
   withTanStackFormMask,
 } from './api';
 
+export { formatWithMask, unformatWithMask } from './core';
+
 export type {
   Input,
   Mask,


### PR DESCRIPTION
Adds standalone format/unformat helpers so consumers can mask and
sanitize plain string values without a mounted input element, useful
for preparing data for the backend and rendering persisted values.

Closes #187