### PR TITLE
fix(react-hook-form): fire onChange on first delete for predefined values

### DIFF
--- a/.changeset/fix-issue-193-onchange-predefined.md
+++ b/.changeset/fix-issue-193-onchange-predefined.md
@@ -1,0 +1,7 @@
+---
+"use-mask-input": patch
+---
+
+fix(react-hook-form): fire `onChange` on the first select-all + delete for predefined values
+
+When a React Hook Form field had a predefined value, the mask was applied before RHF wrote that value onto the element, leaving Inputmask's internal buffer out of sync with the DOM. The first `Ctrl+A` + `Delete` was swallowed and did not trigger `onChange`. The RHF ref now runs before the mask is applied, so Inputmask is seeded with the current value and stays in sync from the start.

--- a/packages/use-mask-input/src/api/useHookFormMask.spec.ts
+++ b/packages/use-mask-input/src/api/useHookFormMask.spec.ts
@@ -66,6 +66,33 @@ describe('useHookFormMask', () => {
     expect(maskFn).toHaveBeenCalled();
   });
 
+  it('calls the RHF ref before applying the mask so predefined values sync (#193)', () => {
+    const input = document.createElement('input');
+    const order: string[] = [];
+    const refCallback = vi.fn(() => order.push('rhf-ref'));
+    const registerFn = vi.fn(() => ({
+      ref: refCallback,
+      prevRef: vi.fn(),
+      onChange: vi.fn(),
+      onBlur: vi.fn(),
+      name: 'phone',
+    }));
+    const maskFn = vi.fn(() => order.push('mask'));
+    vi.mocked(inputmask).mockReturnValue({ mask: maskFn } as any);
+
+    const { result } = renderHook(
+      () => useHookFormMask(registerFn as UseFormRegister<FieldValues>),
+    );
+    const registration = result.current('phone', '999-999');
+
+    registration.ref?.(input);
+
+    // RHF writes the field's predefined value onto the element first; masking
+    // afterwards seeds Inputmask with that value and keeps its buffer in sync.
+    expect(order).toEqual(['rhf-ref', 'mask']);
+    expect(refCallback).toHaveBeenCalledWith(input);
+  });
+
   it('merges register options with mask options', () => {
     const registerFn = makeRegisterFn('phone');
     vi.mocked(inputmask).mockReturnValue({ mask: vi.fn() } as any);

--- a/packages/use-mask-input/src/api/useHookFormMask.spec.ts
+++ b/packages/use-mask-input/src/api/useHookFormMask.spec.ts
@@ -93,6 +93,49 @@ describe('useHookFormMask', () => {
     expect(refCallback).toHaveBeenCalledWith(input);
   });
 
+  it('returns void from the ref callback on mount and detach (React 19 cleanup contract)', () => {
+    // React 19 treats a ref callback's return value as a cleanup function, so
+    // the composed RHF + mask ref must never leak the resolved element or null.
+    const input = document.createElement('input');
+    const registerFn = vi.fn(() => ({
+      // RHF's own ref callback returns void; the composed one must too.
+      ref: vi.fn(() => input),
+      prevRef: vi.fn(),
+      onChange: vi.fn(),
+      onBlur: vi.fn(),
+      name: 'phone',
+    }));
+    vi.mocked(inputmask).mockReturnValue({ mask: vi.fn() } as any);
+
+    const { result } = renderHook(
+      () => useHookFormMask(registerFn as UseFormRegister<FieldValues>),
+    );
+    const registration = result.current('phone', '999-999');
+
+    expect(registration.ref?.(input)).toBeUndefined();
+    expect(registration.ref?.(null)).toBeUndefined();
+  });
+
+  it('returns void from the ref callback when RHF provides no ref', () => {
+    const input = document.createElement('input');
+    const registerFn = vi.fn(() => ({
+      ref: undefined,
+      prevRef: vi.fn(),
+      onChange: vi.fn(),
+      onBlur: vi.fn(),
+      name: 'phone',
+    }));
+    vi.mocked(inputmask).mockReturnValue({ mask: vi.fn() } as any);
+
+    const { result } = renderHook(
+      () => useHookFormMask(registerFn as unknown as UseFormRegister<FieldValues>),
+    );
+    const registration = result.current('phone', '999-999');
+
+    expect(registration.ref?.(input)).toBeUndefined();
+    expect(registration.ref?.(null)).toBeUndefined();
+  });
+
   it('merges register options with mask options', () => {
     const registerFn = makeRegisterFn('phone');
     vi.mocked(inputmask).mockReturnValue({ mask: vi.fn() } as any);

--- a/packages/use-mask-input/src/api/useHookFormMask.ts
+++ b/packages/use-mask-input/src/api/useHookFormMask.ts
@@ -79,9 +79,20 @@ export default function useHookFormMask<
           return _ref;
         };
 
+        // RHF must run first: it writes the field's predefined value onto the
+        // element. If we masked before that, Inputmask would initialise with an
+        // empty buffer and RHF's later value assignment would leave its internal
+        // state out of sync with the DOM, swallowing the first onChange after a
+        // select-all + delete (#193). Masking after RHF seeds Inputmask with the
+        // current value, keeping its buffer in sync from the start.
+        const syncRHFRef = (_ref: HTMLElement | null) => {
+          nextEntry.latestRHFRef?.(_ref);
+          return _ref;
+        };
+
         nextEntry.stableRef = (
           nextEntry.latestRHFRef
-            ? flow(applyMaskToRef, (_ref: HTMLElement | null) => nextEntry.latestRHFRef?.(_ref))
+            ? flow(syncRHFRef, applyMaskToRef)
             : applyMaskToRef
         ) as RefCallback<HTMLElement | null>;
 

--- a/packages/use-mask-input/src/api/useHookFormMask.ts
+++ b/packages/use-mask-input/src/api/useHookFormMask.ts
@@ -90,11 +90,15 @@ export default function useHookFormMask<
           return _ref;
         };
 
-        nextEntry.stableRef = (
-          nextEntry.latestRHFRef
-            ? flow(syncRHFRef, applyMaskToRef)
-            : applyMaskToRef
-        ) as RefCallback<HTMLElement | null>;
+        const composedRef = nextEntry.latestRHFRef
+          ? flow(syncRHFRef, applyMaskToRef)
+          : applyMaskToRef;
+
+        // React 19 treats a ref callback's return value as a cleanup function,
+        // so the composed callback must return void — never the resolved element.
+        nextEntry.stableRef = ((_ref: HTMLElement | null): void => {
+          composedRef(_ref);
+        }) as RefCallback<HTMLElement | null>;
 
         entry = nextEntry;
         entryCacheRef.current.set(cacheKey, nextEntry);


### PR DESCRIPTION
Closes #193.

## Problem

When a React Hook Form field has a predefined value, the first `Ctrl+A` + `Delete` is swallowed and never fires `onChange`. Subsequent deletions work normally.

## Cause

The composed ref callback applied the mask **before** running RHF's own ref. Inputmask initialised against an empty element, and RHF wrote the field's predefined value onto the DOM afterwards, leaving Inputmask's internal buffer out of sync with what the user actually sees.

## Fix

Run the RHF ref first, then apply the mask. Inputmask is now seeded with the current value and its buffer stays in sync from the start.

The composed callback also explicitly returns `void`. React 19 treats a ref callback's return value as a cleanup function, so leaking the resolved element there is a bug in its own right.

## Tests

- ref callback ordering (RHF before mask)
- `void` return on mount and detach
- `void` return when RHF provides no ref
