### PR TITLE
fix: stop maxLength from blocking input on masked fields

### DIFF
--- a/.changeset/fix-issue-191-maxlength-blocks-input.md
+++ b/.changeset/fix-issue-191-maxlength-blocks-input.md
@@ -4,14 +4,15 @@
 
 fix: stop `maxLength` from blocking input on masked fields
 
-A masked input holds the full mask placeholder as its value, so the browser
-counted literals the user never typed against `maxlength` and refused
-keystrokes. inputmask also copied the attribute into its own validator, which
-rejected any buffer longer than it — and the buffer is always the whole mask.
-Together they made any `maxLength` at or below the masked length reject every
-keystroke, and larger values silently truncate.
+A mask like `999.999.999-99` keeps its literals and placeholder in the input's
+value, so `maxlength` counted characters nobody typed. The browser refused
+keystrokes, and inputmask copied the attribute into a validator that rejects any
+buffer longer than it. Any `maxLength` at or below the masked length rejected
+every keystroke, and larger values silently truncated.
 
-The attribute is now removed before the mask is applied, so a `maxLength` left
-on a masked field no longer breaks it.
+The attribute is now removed before the mask is applied, but only for masks that
+render characters on their own. Open-ended masks such as `numeric`, `integer`
+and `decimal` render nothing while empty, so their `maxLength` still caps
+exactly what it says it caps and is left untouched.
 
 Closes #191

--- a/.changeset/fix-issue-191-maxlength-blocks-input.md
+++ b/.changeset/fix-issue-191-maxlength-blocks-input.md
@@ -1,0 +1,17 @@
+---
+"use-mask-input": patch
+---
+
+fix: stop `maxLength` from blocking input on masked fields
+
+A masked input holds the full mask placeholder as its value, so the browser
+counted literals the user never typed against `maxlength` and refused
+keystrokes. inputmask also copied the attribute into its own validator, which
+rejected any buffer longer than it — and the buffer is always the whole mask.
+Together they made any `maxLength` at or below the masked length reject every
+keystroke, and larger values silently truncate.
+
+The attribute is now removed before the mask is applied, so a `maxLength` left
+on a masked field no longer breaks it.
+
+Closes #191

--- a/packages/use-mask-input/src/api/withMask.ts
+++ b/packages/use-mask-input/src/api/withMask.ts
@@ -35,7 +35,7 @@ export default function withMask(mask: Mask, options?: Options): UseMaskInputRet
 
     currentInput = input;
     const maskInput = interopDefaultSync(inputmask)(getMaskOptions(mask, options));
-    stripMaxLength(input);
+    stripMaxLength(input, mask, options);
     maskInput.mask(input as HTMLElement);
   }) as UseMaskInputReturn;
 

--- a/packages/use-mask-input/src/api/withMask.ts
+++ b/packages/use-mask-input/src/api/withMask.ts
@@ -2,6 +2,7 @@
 import inputmask from '../core/inputmask';
 
 import { getMaskOptions } from '../core/maskConfig';
+import { stripMaxLength } from '../core/maskEngine';
 import { getUnmaskedValue, makeMaskCacheKey, setUnmaskedValue } from '../utils';
 import isServer from '../utils/isServer';
 import interopDefaultSync from '../utils/moduleInterop';
@@ -34,6 +35,7 @@ export default function withMask(mask: Mask, options?: Options): UseMaskInputRet
 
     currentInput = input;
     const maskInput = interopDefaultSync(inputmask)(getMaskOptions(mask, options));
+    stripMaxLength(input);
     maskInput.mask(input as HTMLElement);
   }) as UseMaskInputReturn;
 

--- a/packages/use-mask-input/src/core/maskEngine.ts
+++ b/packages/use-mask-input/src/core/maskEngine.ts
@@ -8,6 +8,47 @@ import { moduleInterop } from '../utils';
 import type { Mask, Options } from '../types';
 
 /**
+ * Creates a mask instance with the given mask and options.
+ * Like a factory, but simpler.
+ *
+ * @param mask - The mask pattern
+ * @param options - Optional configuration options
+ * @returns A mask instance
+ */
+export function createMaskInstance(mask: Mask, options?: Options): ReturnType<typeof inputmask> {
+  const inputmaskInstance = moduleInterop(inputmask);
+  return inputmaskInstance(getMaskOptions(mask, options));
+}
+
+/**
+ * Formats a raw value using the given mask, without needing a mounted element.
+ * Useful for displaying already-persisted (unmasked) values in the UI.
+ *
+ * @param value - The raw value to format
+ * @param mask - The mask pattern
+ * @param options - Optional configuration options
+ * @returns The masked value
+ */
+export function formatWithMask(value: string, mask: Mask, options?: Options): string {
+  const inputmaskInstance = moduleInterop(inputmask);
+  return inputmaskInstance.format(value, getMaskOptions(mask, options));
+}
+
+/**
+ * Removes the mask from a formatted value, without needing a mounted element.
+ * Useful for sanitizing input before sending it to the backend.
+ *
+ * @param value - The masked value to unformat
+ * @param mask - The mask pattern
+ * @param options - Optional configuration options
+ * @returns The raw, unmasked value
+ */
+export function unformatWithMask(value: string, mask: Mask, options?: Options): string {
+  const inputmaskInstance = moduleInterop(inputmask);
+  return inputmaskInstance.unmask(value, getMaskOptions(mask, options));
+}
+
+/**
  * Drops the native `maxlength` when the mask renders characters the user never types.
  *
  * A mask like `999.999.999-99` keeps its literals and placeholder in the value, so
@@ -37,19 +78,6 @@ export function stripMaxLength(element: unknown, mask: Mask, options?: Options):
 }
 
 /**
- * Creates a mask instance with the given mask and options.
- * Like a factory, but simpler.
- *
- * @param mask - The mask pattern
- * @param options - Optional configuration options
- * @returns A mask instance
- */
-export function createMaskInstance(mask: Mask, options?: Options): ReturnType<typeof inputmask> {
-  const inputmaskInstance = moduleInterop(inputmask);
-  return inputmaskInstance(getMaskOptions(mask, options));
-}
-
-/**
  * Applies a mask to an input element.
  * If it's not a direct input, searches inside.
  *
@@ -73,32 +101,4 @@ export function applyMaskToElement(
 
   stripMaxLength(target, mask, options);
   maskInstance.mask(target);
-}
-
-/**
- * Formats a raw value using the given mask, without needing a mounted element.
- * Useful for displaying already-persisted (unmasked) values in the UI.
- *
- * @param value - The raw value to format
- * @param mask - The mask pattern
- * @param options - Optional configuration options
- * @returns The masked value
- */
-export function formatWithMask(value: string, mask: Mask, options?: Options): string {
-  const inputmaskInstance = moduleInterop(inputmask);
-  return inputmaskInstance.format(value, getMaskOptions(mask, options));
-}
-
-/**
- * Removes the mask from a formatted value, without needing a mounted element.
- * Useful for sanitizing input before sending it to the backend.
- *
- * @param value - The masked value to unformat
- * @param mask - The mask pattern
- * @param options - Optional configuration options
- * @returns The raw, unmasked value
- */
-export function unformatWithMask(value: string, mask: Mask, options?: Options): string {
-  const inputmaskInstance = moduleInterop(inputmask);
-  return inputmaskInstance.unmask(value, getMaskOptions(mask, options));
 }

--- a/packages/use-mask-input/src/core/maskEngine.ts
+++ b/packages/use-mask-input/src/core/maskEngine.ts
@@ -2,9 +2,29 @@
 import inputmask from './inputmask';
 
 import { getMaskOptions } from './maskConfig';
+import { isHTMLElement } from './elementResolver';
 import { moduleInterop } from '../utils';
 
 import type { Mask, Options } from '../types';
+
+/**
+ * Drops the native `maxlength` before inputmask touches the element.
+ *
+ * A masked input holds the full mask placeholder as its value, so `maxlength`
+ * counts the literals the user never typed and the browser blocks keystrokes
+ * long before the mask is filled. inputmask also copies the attribute into its
+ * own validator, which rejects any buffer longer than it — and the buffer is
+ * always the whole mask. Either way the field ends up unusable, so the
+ * attribute has to go before `mask()` reads it.
+ *
+ * @see https://github.com/eduardoborges/use-mask-input/issues/191
+ * @param element - The element about to be masked
+ */
+export function stripMaxLength(element: unknown): void {
+  if (isHTMLElement(element)) {
+    element.removeAttribute('maxlength');
+  }
+}
 
 /**
  * Creates a mask instance with the given mask and options.
@@ -39,11 +59,10 @@ export function applyMaskToElement(
     ? element
     : (element.querySelector('input') as HTMLElement);
 
-  if (inputElement) {
-    maskInstance.mask(inputElement);
-  } else {
-    maskInstance.mask(element);
-  }
+  const target = inputElement ?? element;
+
+  stripMaxLength(target);
+  maskInstance.mask(target);
 }
 
 /**

--- a/packages/use-mask-input/src/core/maskEngine.ts
+++ b/packages/use-mask-input/src/core/maskEngine.ts
@@ -8,22 +8,32 @@ import { moduleInterop } from '../utils';
 import type { Mask, Options } from '../types';
 
 /**
- * Drops the native `maxlength` before inputmask touches the element.
+ * Drops the native `maxlength` when the mask renders characters the user never types.
  *
- * A masked input holds the full mask placeholder as its value, so `maxlength`
- * counts the literals the user never typed and the browser blocks keystrokes
- * long before the mask is filled. inputmask also copies the attribute into its
- * own validator, which rejects any buffer longer than it — and the buffer is
- * always the whole mask. Either way the field ends up unusable, so the
- * attribute has to go before `mask()` reads it.
+ * A mask like `999.999.999-99` keeps its literals and placeholder in the value, so
+ * `maxlength` counts characters nobody typed: the browser stops accepting keystrokes,
+ * and inputmask copies the attribute into a validator that rejects any buffer longer
+ * than it. Either way the field takes no input at all.
+ *
+ * Open-ended masks (`numeric`, `integer`, `decimal`) render nothing while empty, so
+ * their value only ever holds what was typed and `maxlength` still caps what it says
+ * it caps. Those keep the attribute. Rendering the empty value is what tells the two
+ * apart, since aliases hide their real pattern.
+ *
+ * ponytail: the empty render is a proxy, not a proof. A mask that starts empty but
+ * grows a literal later (`br-bank-agency` gains a `-` at the 6th digit) still loses
+ * that many characters off the cap. Sharpen this only if someone hits it.
  *
  * @see https://github.com/eduardoborges/use-mask-input/issues/191
  * @param element - The element about to be masked
+ * @param mask - The mask pattern about to be applied
+ * @param options - Optional configuration options
  */
-export function stripMaxLength(element: unknown): void {
-  if (isHTMLElement(element)) {
-    element.removeAttribute('maxlength');
-  }
+export function stripMaxLength(element: unknown, mask: Mask, options?: Options): void {
+  if (!isHTMLElement(element) || !element.hasAttribute('maxlength')) return;
+  if (formatWithMask('', mask, options).length === 0) return;
+
+  element.removeAttribute('maxlength');
 }
 
 /**
@@ -61,7 +71,7 @@ export function applyMaskToElement(
 
   const target = inputElement ?? element;
 
-  stripMaxLength(target);
+  stripMaxLength(target, mask, options);
   maskInstance.mask(target);
 }
 

--- a/packages/use-mask-input/src/core/maxLength.spec.ts
+++ b/packages/use-mask-input/src/core/maxLength.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyMaskToElement, createMaskInstance } from './maskEngine';
+import withMask from '../api/withMask';
+
+/**
+ * Behavioral proof for issue #191: a `maxLength` on a masked input used to
+ * block typing entirely. Runs the REAL engine — no mocks — because the bug
+ * lives in how inputmask reads the attribute, not in our own code.
+ *
+ * Two independent layers did the blocking, and both are covered here:
+ *   1. inputmask copies `el.maxLength` into its validator, which rejects any
+ *      buffer longer than it. The buffer is always the full mask, so any
+ *      `maxLength` below the masked length rejects every keystroke. That is
+ *      the layer asserted below, via `setValue`.
+ *   2. the browser counts the mask placeholder already sitting in `value`
+ *      against `maxlength` and refuses the keystroke before inputmask sees it.
+ *      jsdom does not enforce `maxlength`, so this one is covered by asserting
+ *      the attribute is gone from the DOM.
+ */
+function maskedInput(apply: (el: HTMLInputElement) => void, maxLength = 11) {
+  const input = document.createElement('input');
+  input.setAttribute('maxlength', String(maxLength));
+  document.body.appendChild(input);
+  apply(input);
+  return input;
+}
+
+/** Pushes a value through the engine's own validation, the layer that used to reject it. */
+function setValue(input: HTMLInputElement, value: string) {
+  (input as unknown as { inputmask: { setValue: (v: string) => void } })
+    .inputmask.setValue(value);
+  return input.value;
+}
+
+describe('maxLength on a masked input (issue #191)', () => {
+  it('reproduces the block when the attribute survives (control)', () => {
+    const input = document.createElement('input');
+    input.setAttribute('maxlength', '11');
+    document.body.appendChild(input);
+
+    createMaskInstance('cpf').mask(input);
+
+    // 11 digits render as 14 chars, so the validator rejects the whole value
+    expect(setValue(input, '12345678901')).toBe('');
+  });
+
+  it('applyMaskToElement accepts a full value despite a short maxLength', () => {
+    const input = maskedInput((el) => applyMaskToElement(el, 'cpf'));
+
+    expect(input.getAttribute('maxlength')).toBeNull();
+    expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+  });
+
+  it('withMask accepts a full value despite a short maxLength', () => {
+    const input = maskedInput((el) => withMask('999.999.999-99')(el));
+
+    expect(input.getAttribute('maxlength')).toBeNull();
+    expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+  });
+
+  it('strips maxLength from the input inside a wrapper', () => {
+    const wrapper = document.createElement('div');
+    const input = document.createElement('input');
+    input.setAttribute('maxlength', '11');
+    wrapper.appendChild(input);
+    document.body.appendChild(wrapper);
+
+    applyMaskToElement(wrapper, 'cpf');
+
+    expect(input.getAttribute('maxlength')).toBeNull();
+    expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+  });
+
+  it('leaves an input without maxLength alone', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    applyMaskToElement(input, 'cpf');
+
+    expect(input.getAttribute('maxlength')).toBeNull();
+    expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+  });
+});

--- a/packages/use-mask-input/src/core/maxLength.spec.ts
+++ b/packages/use-mask-input/src/core/maxLength.spec.ts
@@ -1,24 +1,29 @@
 import { describe, expect, it } from 'vitest';
 
-import { applyMaskToElement, createMaskInstance } from './maskEngine';
+import { applyMaskToElement, createMaskInstance, stripMaxLength } from './maskEngine';
 import withMask from '../api/withMask';
 
 /**
- * Behavioral proof for issue #191: a `maxLength` on a masked input used to
- * block typing entirely. Runs the REAL engine — no mocks — because the bug
- * lives in how inputmask reads the attribute, not in our own code.
+ * Behavioral proof for issue #191: a `maxLength` on a masked input used to block
+ * typing entirely. Runs the REAL engine — no mocks — because the bug lives in how
+ * inputmask reads the attribute, not in our own code.
  *
- * Two independent layers did the blocking, and both are covered here:
- *   1. inputmask copies `el.maxLength` into its validator, which rejects any
+ * Two layers did the blocking:
+ *   1. the browser counts the mask placeholder already sitting in `value` against
+ *      `maxlength` and refuses the keystroke before inputmask sees it;
+ *   2. inputmask copies `el.maxLength` into its own validator, which rejects any
  *      buffer longer than it. The buffer is always the full mask, so any
- *      `maxLength` below the masked length rejects every keystroke. That is
- *      the layer asserted below, via `setValue`.
- *   2. the browser counts the mask placeholder already sitting in `value`
- *      against `maxlength` and refuses the keystroke before inputmask sees it.
- *      jsdom does not enforce `maxlength`, so this one is covered by asserting
- *      the attribute is gone from the DOM.
+ *      `maxLength` below the masked length rejects every keystroke.
+ *
+ * jsdom reports `ontouchstart`, so inputmask considers it mobile and clears the
+ * attribute itself at the end of `mask()`. Asserting on the attribute after
+ * masking therefore proves nothing here — it is gone either way. Layer 1 is
+ * covered by testing `stripMaxLength` directly, layer 2 behaviorally through
+ * `setValue`. That mobile path is also the one inputmask gets wrong on its own:
+ * it removes the attribute only after reading it into the validator.
  */
-function maskedInput(apply: (el: HTMLInputElement) => void, maxLength = 11) {
+
+function maskedInput(apply: (el: HTMLInputElement) => void, maxLength: number) {
   const input = document.createElement('input');
   input.setAttribute('maxlength', String(maxLength));
   document.body.appendChild(input);
@@ -33,6 +38,12 @@ function setValue(input: HTMLInputElement, value: string) {
   return input.value;
 }
 
+function inputWithMaxLength(maxLength: number) {
+  const input = document.createElement('input');
+  input.setAttribute('maxlength', String(maxLength));
+  return input;
+}
+
 describe('maxLength on a masked input (issue #191)', () => {
   it('reproduces the block when the attribute survives (control)', () => {
     const input = document.createElement('input');
@@ -45,40 +56,95 @@ describe('maxLength on a masked input (issue #191)', () => {
     expect(setValue(input, '12345678901')).toBe('');
   });
 
-  it('applyMaskToElement accepts a full value despite a short maxLength', () => {
-    const input = maskedInput((el) => applyMaskToElement(el, 'cpf'));
+  describe('stripMaxLength', () => {
+    it('removes the attribute for a mask that renders literals', () => {
+      const input = inputWithMaxLength(11);
 
-    expect(input.getAttribute('maxlength')).toBeNull();
-    expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+      stripMaxLength(input, 'cpf');
+
+      expect(input.hasAttribute('maxlength')).toBe(false);
+    });
+
+    it('removes it for a mask that renders a prefix', () => {
+      const input = inputWithMaxLength(3);
+
+      stripMaxLength(input, 'currency');
+
+      expect(input.hasAttribute('maxlength')).toBe(false);
+    });
+
+    it.each(['numeric', 'integer', 'decimal'])('keeps it for the open-ended %s mask', (mask) => {
+      const input = inputWithMaxLength(3);
+
+      stripMaxLength(input, mask);
+
+      expect(input.getAttribute('maxlength')).toBe('3');
+    });
+
+    it('ignores an element that never had the attribute', () => {
+      const input = document.createElement('input');
+
+      stripMaxLength(input, 'cpf');
+
+      expect(input.hasAttribute('maxlength')).toBe(false);
+    });
+
+    it('ignores a non-element', () => {
+      expect(() => stripMaxLength(null, 'cpf')).not.toThrow();
+    });
   });
 
-  it('withMask accepts a full value despite a short maxLength', () => {
-    const input = maskedInput((el) => withMask('999.999.999-99')(el));
+  describe('a fixed mask accepts its full value despite a short maxLength', () => {
+    it('via applyMaskToElement', () => {
+      const input = maskedInput((el) => applyMaskToElement(el, 'cpf'), 11);
 
-    expect(input.getAttribute('maxlength')).toBeNull();
-    expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+      expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+    });
+
+    it('via withMask', () => {
+      const input = maskedInput((el) => withMask('999.999.999-99')(el), 11);
+
+      expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+    });
+
+    it('for an input inside a wrapper', () => {
+      const wrapper = document.createElement('div');
+      const input = document.createElement('input');
+      input.setAttribute('maxlength', '11');
+      wrapper.appendChild(input);
+      document.body.appendChild(wrapper);
+
+      applyMaskToElement(wrapper, 'cpf');
+
+      expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+    });
+
+    it('when no maxLength was set at all', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+
+      applyMaskToElement(input, 'cpf');
+
+      expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+    });
   });
 
-  it('strips maxLength from the input inside a wrapper', () => {
-    const wrapper = document.createElement('div');
-    const input = document.createElement('input');
-    input.setAttribute('maxlength', '11');
-    wrapper.appendChild(input);
-    document.body.appendChild(wrapper);
+  /**
+   * An open-ended mask renders nothing while empty, so its value only ever holds
+   * what the user typed and `maxLength` caps exactly what it claims to. Stripping
+   * it there would throw away a limit that works.
+   */
+  describe('an open-ended mask still honors its maxLength', () => {
+    it.each(['numeric', 'integer', 'decimal'])('%s caps the value', (mask) => {
+      const input = maskedInput((el) => applyMaskToElement(el, mask), 3);
 
-    applyMaskToElement(wrapper, 'cpf');
+      expect(setValue(input, '1234')).toBe('123');
+    });
 
-    expect(input.getAttribute('maxlength')).toBeNull();
-    expect(setValue(input, '12345678901')).toBe('123.456.789-01');
-  });
+    it('via withMask too', () => {
+      const input = maskedInput((el) => withMask('numeric')(el), 3);
 
-  it('leaves an input without maxLength alone', () => {
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-
-    applyMaskToElement(input, 'cpf');
-
-    expect(input.getAttribute('maxlength')).toBeNull();
-    expect(setValue(input, '12345678901')).toBe('123.456.789-01');
+      expect(setValue(input, '1234')).toBe('123');
+    });
   });
 });


### PR DESCRIPTION
Closes #191

## The bug

A `maxLength` on a masked input doesn't limit it, it breaks it. Reproduced in `apps/vite-project` with mask `999.999.999-99` (11 digits, 14 chars), typing `12345678901`:

| `maxLength` | result | chars accepted |
|---|---|---|
| absent | `123.456.789-01` | 11 |
| 11 | `""` | 0 |
| 13 | `""` | 0 |
| 14 (exact masked length) | `""` | 0 |
| 15 | `___.___.__1-__` | 1 |
| 20 | `123.456.___-__` | 6 |

Accepted characters come out to exactly `maxLength - 14`. The issue title says "less than the number of characters in the mask", but any `maxLength` breaks the field, including values larger than the mask.

## Why

Two separate layers were blocking input.

The first is the browser. With `showMaskOnFocus` (on by default), inputmask fills the input with the full placeholder `___.___.___-__` when it gets focus. The value is already 14 characters before the user types anything, so the native `maxlength` constraint rejects every keystroke past the limit. That's why `maxLength={14}` blocks everything and `maxLength={20}` lets exactly 6 through.

The second is inputmask's own validator. [`mask.js:235`](https://github.com/RobinHerbots/Inputmask/blob/5.x/lib/mask.js) copies `el.maxLength` into `inputmask.maxLength`, and [`validation.js:766`](https://github.com/RobinHerbots/Inputmask/blob/5.x/lib/validation.js) invalidates anything where `buffer.length > maxLength`. The buffer is always the complete mask, so any `maxLength` below the masked length rejects everything without the browser being involved at all.

inputmask knows about this. `mask.js:271` calls `el.removeAttribute("maxLength")`, but only on mobile or with `inputEventOnly`, and only after it has already read the value into `inputmask.maxLength`. So mobile stays broken through the second layer.

## The fix

Remove the attribute before `mask()` runs. inputmask reads it from inside `mask()`, so one removal covers both layers, including the mobile path.

Not every mask should lose it though. An open-ended mask renders nothing while empty, so its value only ever holds what the user typed and `maxLength` caps exactly what it claims to:

| mask | renders when empty | `maxLength=3`, typing `1234` |
|---|---|---|
| `numeric` / `integer` / `decimal` | `""` | `"123"`, cap works |
| `br-bank-agency` | `""` | cap works |
| `cpf` | `"___.___.___-__"` | `""`, broken |
| `currency` | `"$ ."` | `""`, broken |

So `stripMaxLength()` in `core/maskEngine.ts` decides by rendering the empty value through the existing `formatWithMask()` helper. Characters with no input means the mask inflates the value beyond what was typed, and the attribute goes. Nothing rendered means it stays. Aliases hide their real pattern, so rendering is the only reliable way to tell the two apart. The check only runs when a `maxlength` is actually present, so masks without one pay nothing.

It's called at the only two places that reach `.mask()`:

- `applyMaskToElement`, which covers `useHookFormMask`, `useTanStackFormMask`, the `with*` variants and the antd entry
- `withMask`, which covers `useMaskInput` since that delegates to it

The empty render is a proxy rather than a proof. `br-bank-agency` starts empty but grows a `-` at the 6th digit, so a cap there still loses one character. That's marked with a `ponytail:` comment instead of a general solution, since nobody has hit it.

## Notes for review

This isn't what the issue author asked for. They suggested deriving `maxLength` from the mask automatically. The table shows why that wouldn't help: `maxLength={14}` blocks just as hard as `11`.

Dropping a user's attribute without asking is still a behavior change, but only where there's nothing to preserve. On those masks the attribute disables the field rather than limiting it. If you want fewer characters there, use a shorter mask.

I didn't add an opt-out option. Happy to add one if a real case turns up.

## Verification

`src/core/maxLength.spec.ts` has 16 tests against the real engine with no mocks, since the bug is in how inputmask reads the attribute rather than in our own code. The first is a control: it masks through `createMaskInstance` without the strip and asserts `''`, so the suite fails if the fix is reverted. The rest cover both entry points, an input inside a wrapper, an input with no `maxLength`, and the open-ended masks that must keep their cap.

One thing worth knowing about this suite: jsdom reports `ontouchstart`, so inputmask considers it mobile and clears the attribute itself at the end of `mask()`. Asserting on the attribute after masking proves nothing there, it's gone either way. My first version of the spec did exactly that and passed for the wrong reason. Layer 1 is now tested through `stripMaxLength` directly, layer 2 behaviorally through `setValue`. As a side effect the jsdom suite exercises the mobile path, which is the one inputmask gets wrong on its own.

The native layer needs a real browser, so I checked it by hand in `apps/vite-project`. All six cases pass: `cpf` with no `maxLength`, with 11, 14 and 20 all accept `123.456.789-01`, and `numeric` and `integer` with `maxLength={3}` still cap `1234` at `123`.

Suite: 207 passed, lint and type-check clean.
