### PR TITLE
test: backfill real-browser tests for the React surface (#198)

### DIFF
--- a/packages/use-mask-input/package.json
+++ b/packages/use-mask-input/package.json
@@ -93,6 +93,7 @@
   },
   "devDependencies": {
     "@codecov/rollup-plugin": "^2.0.1",
+    "@tanstack/react-form": "^1.33.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/inputmask": "5.0.7",

--- a/packages/use-mask-input/src/antd/useMaskInputAntd.browser.spec.ts
+++ b/packages/use-mask-input/src/antd/useMaskInputAntd.browser.spec.ts
@@ -1,0 +1,179 @@
+/* eslint-disable import-x/no-extraneous-dependencies */
+import { userEvent } from '@vitest/browser/context';
+import { Input } from 'antd';
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { useForm } from 'react-hook-form';
+import {
+  afterEach, describe, expect, it,
+} from 'vitest';
+
+import useHookFormMaskAntd from './useHookFormMaskAntd';
+import useMaskInputAntd from './useMaskInputAntd';
+
+import type { ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+import type { UseFormReturn } from 'react-hook-form';
+
+/**
+ * Ant Design resolution, end to end.
+ *
+ * The `unit` project proves `resolveInputRef` picks the inner `<input>` out of
+ * an `InputRef`, but it stops at the ref. What it cannot show is that the
+ * element it picked is the one the user's keystrokes land on: with a `prefix`
+ * or an addon, antd wraps the real input in a `<span>`, and masking the wrong
+ * node fails silently — the ref assertion still passes and nothing formats.
+ *
+ * antd's Input is also internally controlled, so it owns `el.value` on every
+ * render. Anything the mask writes has to survive that, which is a round trip
+ * jsdom's approximate input handling cannot exercise.
+ */
+
+interface Values { cpf: string }
+
+const CPF = '12345678901';
+
+let active: { root: Root; host: HTMLDivElement } | null = null;
+
+function mount(element: ReactElement): HTMLInputElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+
+  const root = createRoot(host);
+  flushSync(() => { root.render(element); });
+  active = { root, host };
+
+  const input = host.querySelector('input');
+  if (!input) throw new Error('no input rendered');
+
+  return input;
+}
+
+afterEach(() => {
+  active?.root.unmount();
+  active?.host.remove();
+  active = null;
+});
+
+/** The masked text the user sees; `el.value` returns unmasked under autoUnmask. */
+function displayed(el: HTMLInputElement): string {
+  const native = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+  return native?.get?.call(el) as string;
+}
+
+const nextFrame = () => new Promise((resolve) => {
+  requestAnimationFrame(() => resolve(null));
+});
+
+/** Inputmask moves the caret on focus — typing into that gap misplaces digits. */
+async function focus(el: HTMLInputElement) {
+  await userEvent.click(el);
+  await nextFrame();
+}
+
+describe('useMaskInputAntd', () => {
+  it('masks the inner input, not the wrapper antd renders around it', async () => {
+    function Field() {
+      const ref = useMaskInputAntd({ mask: 'cpf' });
+      // `prefix` makes antd render <span class="ant-input-affix-wrapper"> around
+      // the real <input>, which is the case resolution has to get right.
+      return createElement(Input, { ref, prefix: '#' });
+    }
+
+    const input = mount(createElement(Field));
+
+    expect(input.parentElement?.tagName).toBe('SPAN');
+    expect((input as HTMLInputElement & { inputmask?: unknown }).inputmask).toBeDefined();
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+
+    expect(displayed(input)).toBe('123.456.789-01');
+  });
+
+  it('formats through a plain antd Input as the user types', async () => {
+    function Field() {
+      const ref = useMaskInputAntd({ mask: '(99) 99999-9999' });
+      return createElement(Input, { ref });
+    }
+
+    const input = mount(createElement(Field));
+
+    await focus(input);
+    await userEvent.type(input, '11987654321');
+
+    expect(displayed(input)).toBe('(11) 98765-4321');
+  });
+
+  it('exposes the typed digits through unmaskedValue()', async () => {
+    let ref: ReturnType<typeof useMaskInputAntd> | undefined;
+
+    function Field() {
+      ref = useMaskInputAntd({ mask: 'cpf', options: { autoUnmask: true } });
+      return createElement(Input, { ref });
+    }
+
+    const input = mount(createElement(Field));
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+
+    expect(displayed(input)).toBe('123.456.789-01');
+    expect(ref?.unmaskedValue()).toBe(CPF);
+  });
+});
+
+describe('useHookFormMaskAntd', () => {
+  it('round trips autoUnmask through an antd-wrapped field', async () => {
+    let form: UseFormReturn<Values> | undefined;
+
+    function Form() {
+      const api = useForm<Values>({ defaultValues: { cpf: '' } });
+      form = api;
+      const registerWithMask = useHookFormMaskAntd(api.register);
+      return createElement(Input, {
+        ...registerWithMask('cpf', 'cpf', { autoUnmask: true }),
+        prefix: '#',
+      });
+    }
+
+    const input = mount(createElement(Form));
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+
+    expect(displayed(input)).toBe('123.456.789-01');
+    expect(form?.getValues('cpf')).toBe(CPF);
+  });
+
+  it('registers the first delete after the user fills the field', async () => {
+    // The plain-input version of this seeds the value from RHF's defaultValues
+    // (see api/useHookFormMask.browser.spec.ts). That is not available here:
+    // antd's Input is internally controlled and overwrites the value RHF writes
+    // onto the DOM, mask or no mask. So the value gets there by typing.
+    let form: UseFormReturn<Values> | undefined;
+
+    function Form() {
+      const api = useForm<Values>({ defaultValues: { cpf: '' } });
+      form = api;
+      const registerWithMask = useHookFormMaskAntd(api.register);
+      return createElement(Input, registerWithMask('cpf', 'cpf', { autoUnmask: true }));
+    }
+
+    const input = mount(createElement(Form));
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+    expect(form?.getValues('cpf')).toBe(CPF);
+
+    // select-all via the element rather than a chord: it is Meta+A on macOS and
+    // Control+A elsewhere, and this spec has to pass on both.
+    input.select();
+    await userEvent.keyboard('{Delete}');
+    await userEvent.type(input, '98765432100');
+
+    expect(displayed(input)).toBe('987.654.321-00');
+    expect(form?.getValues('cpf')).toBe('98765432100');
+  });
+});

--- a/packages/use-mask-input/src/api/useHookFormMask.browser.spec.ts
+++ b/packages/use-mask-input/src/api/useHookFormMask.browser.spec.ts
@@ -1,0 +1,183 @@
+/* eslint-disable import-x/no-extraneous-dependencies */
+import { userEvent } from '@vitest/browser/context';
+import { createElement, useEffect } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { useForm } from 'react-hook-form';
+import {
+  afterEach, describe, expect, it,
+} from 'vitest';
+
+import useHookFormMask from './useHookFormMask';
+import withHookFormMask from './withHookFormMask';
+
+import type { ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+import type { UseFormReturn } from 'react-hook-form';
+
+/**
+ * #193 by symptom, in a real browser.
+ *
+ * The `unit` project proves the fix as call *ordering* — that RHF's ref runs
+ * before the mask is applied — because jsdom cannot deliver the sequence that
+ * actually broke: a predefined value, select all, delete, retype. Inputmask
+ * initialised with an empty buffer while RHF wrote the field's value straight
+ * onto the element, so its internal state and the DOM disagreed and the first
+ * `onChange` after the delete was swallowed. That is a keyboard bug, and it
+ * needs a keyboard.
+ */
+
+interface Values { cpf: string }
+
+const CPF = '12345678901';
+
+let active: { root: Root; host: HTMLDivElement } | null = null;
+
+function mount(element: ReactElement): HTMLInputElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+
+  const root = createRoot(host);
+  flushSync(() => { root.render(element); });
+  active = { root, host };
+
+  const input = host.querySelector('input');
+  if (!input) throw new Error('no input rendered');
+
+  return input;
+}
+
+afterEach(() => {
+  active?.root.unmount();
+  active?.host.remove();
+  active = null;
+});
+
+/** The masked text the user sees; `el.value` returns unmasked under autoUnmask. */
+function displayed(el: HTMLInputElement): string {
+  const native = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+  return native?.get?.call(el) as string;
+}
+
+const nextFrame = () => new Promise((resolve) => {
+  requestAnimationFrame(() => resolve(null));
+});
+
+/** Inputmask moves the caret on focus — typing into that gap misplaces digits. */
+async function focus(el: HTMLInputElement) {
+  await userEvent.click(el);
+  await nextFrame();
+}
+
+interface Harness {
+  input: HTMLInputElement;
+  form: UseFormReturn<Values>;
+  changes: string[];
+}
+
+/**
+ * A single masked RHF field, plus every value `watch` has seen since mount.
+ * `changes` is how "did onChange fire?" is asked without reaching into RHF's
+ * internals: the subscription only receives a value when the field's change
+ * handler ran.
+ */
+function renderForm(
+  defaultValue: string,
+  variant: 'hook' | 'with' = 'hook',
+): Harness {
+  const changes: string[] = [];
+  let form: UseFormReturn<Values> | undefined;
+
+  function Form() {
+    const api = useForm<Values>({ defaultValues: { cpf: defaultValue } });
+    form = api;
+
+    const registerWithMask = useHookFormMask(api.register);
+
+    useEffect(() => {
+      const subscription = api.watch((values) => { changes.push(values.cpf as string); });
+      return () => subscription.unsubscribe();
+    }, [api]);
+
+    const props = variant === 'hook'
+      ? registerWithMask('cpf', 'cpf', { autoUnmask: true })
+      : withHookFormMask(api.register('cpf'), 'cpf', { autoUnmask: true });
+
+    return createElement('input', props);
+  }
+
+  const input = mount(createElement(Form));
+
+  return { input, form: form as UseFormReturn<Values>, changes };
+}
+
+describe('react-hook-form with a predefined value (#193)', () => {
+  it('masks the value RHF writes on mount', () => {
+    const { input } = renderForm(CPF);
+
+    expect(displayed(input)).toBe('123.456.789-01');
+  });
+
+  it('fires onChange on the very first delete', async () => {
+    const { input, changes } = renderForm(CPF);
+
+    await focus(input);
+    // select-all via the element rather than a chord: it is Meta+A on macOS and
+    // Control+A elsewhere, and this spec has to pass on both.
+    input.select();
+    await userEvent.keyboard('{Delete}');
+
+    // Before the fix this array stayed empty: Inputmask's buffer had never seen
+    // RHF's value, so the delete produced no change RHF could observe.
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes[0]).not.toBe(CPF);
+  });
+
+  it('retypes cleanly after the delete', async () => {
+    const { input, form } = renderForm(CPF);
+
+    await focus(input);
+    input.select();
+    await userEvent.keyboard('{Delete}');
+    await userEvent.type(input, '98765432100');
+
+    expect(displayed(input)).toBe('987.654.321-00');
+    expect(form.getValues('cpf')).toBe('98765432100');
+  });
+});
+
+describe('react-hook-form autoUnmask round trip', () => {
+  it('keeps the display masked and the form value raw', async () => {
+    const { input, form } = renderForm('');
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+
+    expect(displayed(input)).toBe('123.456.789-01');
+    expect(form.getValues('cpf')).toBe(CPF);
+  });
+
+  it('submits the raw value', async () => {
+    const { input, form } = renderForm('');
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+
+    let submitted: Values | undefined;
+    await form.handleSubmit((values) => { submitted = values; })();
+
+    expect(submitted).toEqual({ cpf: CPF });
+    // the display never stopped being masked
+    expect(displayed(input)).toBe('123.456.789-01');
+  });
+
+  it('round trips the same way through withHookFormMask', async () => {
+    const { input, form } = renderForm('', 'with');
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+
+    expect(displayed(input)).toBe('123.456.789-01');
+    expect(form.getValues('cpf')).toBe(CPF);
+  });
+});

--- a/packages/use-mask-input/src/api/useMaskInput.browser.spec.ts
+++ b/packages/use-mask-input/src/api/useMaskInput.browser.spec.ts
@@ -1,0 +1,220 @@
+/* eslint-disable import-x/no-extraneous-dependencies */
+import { userEvent } from '@vitest/browser/context';
+import { createElement, useState } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import {
+  afterEach, describe, expect, it,
+} from 'vitest';
+
+import useMaskInput from './useMaskInput';
+import withMask from './withMask';
+
+import type { ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+import type { Mask, Options } from '../types';
+
+/**
+ * The React counterpart of `src/vue/directive.browser.spec.ts`, and the parts
+ * jsdom cannot prove.
+ *
+ * The `unit` project deliberately never simulates a keystroke — see the header
+ * comments in core/optionsPassthrough.spec.ts and core/maxLength.spec.ts for
+ * why. jsdom reports `ontouchstart`, so Inputmask takes its mobile path and
+ * clears `maxlength` itself; caret and selection behaviour is approximate; and
+ * simulated input does not round-trip through the engine the way a real browser
+ * does. #191 is therefore covered there by calling `stripMaxLength` directly
+ * rather than by symptom. Here it is the symptom.
+ *
+ * Mounting goes through `createRoot` rather than a testing library, mirroring
+ * how the Vue specs hand-roll `createApp`: these tests drive real Chromium
+ * events, and an `act` environment would only add warnings around them.
+ */
+
+let active: { root: Root; host: HTMLDivElement } | null = null;
+
+function mount(element: ReactElement): HTMLInputElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+
+  const root = createRoot(host);
+  flushSync(() => { root.render(element); });
+  active = { root, host };
+
+  const input = host.querySelector('input');
+  if (!input) throw new Error('no input rendered');
+
+  return input;
+}
+
+afterEach(() => {
+  active?.root.unmount();
+  active?.host.remove();
+  active = null;
+});
+
+/**
+ * The text the user actually sees.
+ *
+ * Inputmask replaces the element's `value` property, and under `autoUnmask` its
+ * getter returns the *unmasked* value. Reading the masked display therefore has
+ * to go through the native descriptor.
+ */
+function displayed(el: HTMLInputElement): string {
+  const native = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+  return native?.get?.call(el) as string;
+}
+
+const nextFrame = () => new Promise((resolve) => {
+  requestAnimationFrame(() => resolve(null));
+});
+
+/**
+ * Inputmask repositions the caret when the field receives focus. Typing into
+ * that gap lands the digits in the wrong section — on numeric and currency
+ * masks they end up in the decimal part — and it looks exactly like a library
+ * bug when it is not one. So: focus, then leave a beat.
+ */
+async function focus(el: HTMLInputElement) {
+  await userEvent.click(el);
+  await nextFrame();
+}
+
+function renderHooked(mask: Mask, options?: Options, props?: Record<string, unknown>) {
+  function Field() {
+    const ref = useMaskInput({ mask, options });
+    return createElement('input', { ...props, ref });
+  }
+
+  return mount(createElement(Field));
+}
+
+describe('typing through a mask in a real browser', () => {
+  it('formats a cpf alias as the user types', async () => {
+    const input = renderHooked('cpf');
+
+    await focus(input);
+    await userEvent.type(input, '12345678901');
+
+    expect(displayed(input)).toBe('123.456.789-01');
+  });
+
+  it('formats a raw pattern as the user types', async () => {
+    const input = renderHooked('(99) 99999-9999');
+
+    await focus(input);
+    await userEvent.type(input, '11987654321');
+
+    expect(displayed(input)).toBe('(11) 98765-4321');
+  });
+
+  it('matches the longer pattern from an array as input grows', async () => {
+    const input = renderHooked(['999-999', '999-999-999']);
+
+    await focus(input);
+    await userEvent.type(input, '123456789');
+
+    expect(displayed(input)).toBe('123-456-789');
+  });
+
+  it('formats through withMask, with no hook involved', async () => {
+    const input = mount(createElement('input', { ref: withMask('cpf') }));
+
+    await focus(input);
+    await userEvent.type(input, '12345678901');
+
+    expect(displayed(input)).toBe('123.456.789-01');
+  });
+
+  it('exposes the typed digits through unmaskedValue()', async () => {
+    let ref: ReturnType<typeof useMaskInput> | undefined;
+
+    function Field() {
+      ref = useMaskInput({ mask: 'cpf' });
+      return createElement('input', { ref });
+    }
+
+    const input = mount(createElement(Field));
+
+    await focus(input);
+    await userEvent.type(input, '12345678901');
+
+    expect(displayed(input)).toBe('123.456.789-01');
+    expect(ref?.unmaskedValue()).toBe('12345678901');
+  });
+});
+
+describe('maxLength on a masked input (#191)', () => {
+  it('does not block typing on a literal-bearing mask', async () => {
+    // jsdom cannot show this: it reports ontouchstart, so Inputmask clears the
+    // attribute itself there and the assertion proves nothing. Without the fix
+    // the browser counts the mask placeholder against maxlength and refuses the
+    // keystroke before Inputmask ever sees it.
+    const input = renderHooked('cpf', undefined, { maxLength: 11 });
+
+    await focus(input);
+    await userEvent.type(input, '12345678901');
+
+    expect(displayed(input)).toBe('123.456.789-01');
+  });
+
+  it('does not block typing when the mask comes from withMask', async () => {
+    const input = mount(createElement('input', {
+      maxLength: 11,
+      ref: withMask('(99) 99999-9999'),
+    }));
+
+    await focus(input);
+    await userEvent.type(input, '11987654321');
+
+    expect(displayed(input)).toBe('(11) 98765-4321');
+  });
+
+  it('leaves maxlength alone for an open-ended mask', () => {
+    const input = renderHooked('numeric', undefined, { maxLength: 5 });
+
+    expect(input.getAttribute('maxlength')).toBe('5');
+  });
+});
+
+describe('caret behaviour', () => {
+  it('keeps the caret with the inserted character mid-value', async () => {
+    const input = renderHooked('cpf');
+
+    await focus(input);
+    await userEvent.type(input, '12345678');
+    expect(displayed(input)).toBe('123.456.78_-__');
+
+    // between the first group's separator and the second group
+    input.setSelectionRange(4, 4);
+    await userEvent.type(input, '9');
+
+    expect(displayed(input)).toBe('123.945.678-__');
+    expect(input.selectionStart).toBe(5);
+  });
+
+  it('keeps value and caret when a re-render leaves the mask unchanged', async () => {
+    let bump: (() => void) | undefined;
+
+    function Field() {
+      const [spare, setSpare] = useState(0);
+      const ref = useMaskInput({ mask: 'cpf' });
+      bump = () => setSpare((n) => n + 1);
+      return createElement('div', null, spare, createElement('input', { ref }));
+    }
+
+    const input = mount(createElement(Field));
+
+    await focus(input);
+    await userEvent.type(input, '12345678');
+
+    const valueBefore = displayed(input);
+    input.setSelectionRange(4, 4);
+
+    flushSync(() => { bump?.(); });
+    await nextFrame();
+
+    expect(displayed(input)).toBe(valueBefore);
+    expect(input.selectionStart).toBe(4);
+  });
+});

--- a/packages/use-mask-input/src/api/useTanStackFormMask.browser.spec.ts
+++ b/packages/use-mask-input/src/api/useTanStackFormMask.browser.spec.ts
@@ -1,0 +1,191 @@
+/* eslint-disable import-x/no-extraneous-dependencies */
+import { userEvent } from '@vitest/browser/context';
+import { useForm } from '@tanstack/react-form';
+import { createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import {
+  afterEach, describe, expect, it,
+} from 'vitest';
+
+import useTanStackFormMask from './useTanStackFormMask';
+import withTanStackFormMask from './withTanStackFormMask';
+
+import type { ChangeEvent, ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+
+/**
+ * The TanStack Form integration against the real library, in a real browser.
+ *
+ * The `unit` project drives these helpers with a hand-built `inputProps` object
+ * and a mocked engine, which proves the ref plumbing but not the loop that
+ * matters: TanStack owns `value` as a controlled prop, so every keystroke sends
+ * the value out through `onChange` and back in through a re-render. Under
+ * `autoUnmask` those two directions carry *different* strings — raw out, raw
+ * back into a masked display — and only a real engine round trip can show they
+ * agree.
+ */
+
+interface Values { cpf: string }
+
+const CPF = '12345678901';
+
+/** The public shape of a TanStack field, narrowed to what these specs touch. */
+interface FieldLike {
+  name: string;
+  state: { value: string };
+  handleBlur: () => void;
+  handleChange: (value: string) => void;
+}
+
+let active: { root: Root; host: HTMLDivElement } | null = null;
+
+function mount(element: ReactElement): HTMLInputElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+
+  const root = createRoot(host);
+  flushSync(() => { root.render(element); });
+  active = { root, host };
+
+  const input = host.querySelector('input');
+  if (!input) throw new Error('no input rendered');
+
+  return input;
+}
+
+afterEach(() => {
+  active?.root.unmount();
+  active?.host.remove();
+  active = null;
+});
+
+/** The masked text the user sees; `el.value` returns unmasked under autoUnmask. */
+function displayed(el: HTMLInputElement): string {
+  const native = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+  return native?.get?.call(el) as string;
+}
+
+const nextFrame = () => new Promise((resolve) => {
+  requestAnimationFrame(() => resolve(null));
+});
+
+/** Inputmask moves the caret on focus — typing into that gap misplaces digits. */
+async function focus(el: HTMLInputElement) {
+  await userEvent.click(el);
+  await nextFrame();
+}
+
+interface Harness {
+  input: HTMLInputElement;
+  values: () => Values;
+  submit: () => Promise<void>;
+  submitted: () => Values | undefined;
+}
+
+/**
+ * One masked field wired the way `apps/tanstack-form-project` wires it: the
+ * hook variant memoises across renders, the `with*` variant is the escape hatch
+ * for `React.memo` children.
+ */
+function renderForm(variant: 'hook' | 'with' = 'hook'): Harness {
+  let submitted: Values | undefined;
+  let read: (() => Values) | undefined;
+  let submit: (() => Promise<void>) | undefined;
+
+  function Form() {
+    const maskField = useTanStackFormMask();
+    const form = useForm({
+      defaultValues: { cpf: '' } as Values,
+      onSubmit: ({ value }) => { submitted = value; },
+    });
+
+    read = () => form.state.values;
+    submit = () => form.handleSubmit();
+
+    // `children` goes in the props object, not as createElement's third
+    // argument: TanStack types Field's render prop as a *required prop*, and
+    // createElement's variadic-children overload only accepts a ReactNode, not
+    // a render function. Identical at runtime — React writes the third argument
+    // to props.children anyway.
+    return createElement(form.Field, {
+      name: 'cpf' as const,
+      // eslint-disable-next-line react/no-children-prop
+      children: (field: FieldLike) => {
+        const inputProps = {
+          name: field.name,
+          value: field.state.value,
+          onBlur: field.handleBlur,
+          onChange: (event: ChangeEvent<HTMLInputElement>) => {
+            field.handleChange(event.target.value);
+          },
+        };
+
+        return createElement('input', variant === 'hook'
+          ? maskField('cpf', inputProps, { autoUnmask: true })
+          : withTanStackFormMask(inputProps, 'cpf', { autoUnmask: true }));
+      },
+    });
+  }
+
+  const input = mount(createElement(Form));
+
+  return {
+    input,
+    values: () => (read as () => Values)(),
+    submit: () => (submit as () => Promise<void>)(),
+    submitted: () => submitted,
+  };
+}
+
+describe('tanstack form autoUnmask round trip', () => {
+  it('keeps the display masked and the field value raw', async () => {
+    const { input, values } = renderForm();
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+
+    expect(displayed(input)).toBe('123.456.789-01');
+    await expect.poll(() => values().cpf).toBe(CPF);
+  });
+
+  it('survives the controlled re-render each keystroke triggers', async () => {
+    // TanStack writes `value` back as a prop. React compares it against the
+    // element's getter, which returns the unmasked value under autoUnmask, so
+    // the two agree and the masked buffer is never clobbered mid-typing.
+    const { input, values } = renderForm();
+
+    await focus(input);
+    await userEvent.type(input, '123');
+    expect(displayed(input)).toBe('123.___.___-__');
+
+    await userEvent.type(input, '45678901');
+
+    expect(displayed(input)).toBe('123.456.789-01');
+    await expect.poll(() => values().cpf).toBe(CPF);
+  });
+
+  it('submits the raw value', async () => {
+    const {
+      input, submit, submitted,
+    } = renderForm();
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+    await submit();
+
+    await expect.poll(() => submitted()).toEqual({ cpf: CPF });
+    // the display never stopped being masked
+    expect(displayed(input)).toBe('123.456.789-01');
+  });
+
+  it('round trips the same way through withTanStackFormMask', async () => {
+    const { input, values } = renderForm('with');
+
+    await focus(input);
+    await userEvent.type(input, CPF);
+
+    expect(displayed(input)).toBe('123.456.789-01');
+    await expect.poll(() => values().cpf).toBe(CPF);
+  });
+});

--- a/packages/use-mask-input/vitest.config.ts
+++ b/packages/use-mask-input/vitest.config.ts
@@ -9,11 +9,12 @@ import { defineConfig } from 'vitest/config';
  * keyboard: configuration, element resolution, and Vue's mount/update/unmount
  * lifecycle.
  *
- * `browser` is deliberately small and covers only what jsdom demonstrably gets
- * wrong. jsdom reports `ontouchstart`, so Inputmask takes its mobile path and
- * clears `maxlength` itself (see maxLength.spec.ts); caret and selection APIs
- * are approximations; and simulated keystrokes do not round-trip through the
- * engine the way a real browser does. Those cases live in `*.browser.spec.ts`.
+ * `browser` covers only what jsdom demonstrably gets wrong, for both frameworks.
+ * jsdom reports `ontouchstart`, so Inputmask takes its mobile path and clears
+ * `maxlength` itself (see maxLength.spec.ts); caret and selection APIs are
+ * approximations; and simulated keystrokes do not round-trip through the engine
+ * the way a real browser does. Those cases live in `*.browser.spec.ts` — which
+ * is why #191 and #193 are proven here by symptom rather than by proxy.
  */
 export default defineConfig({
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@codecov/rollup-plugin':
         specifier: ^2.0.1
         version: 2.0.1(rollup@4.61.1)
+      '@tanstack/react-form':
+        specifier: ^1.33.2
+        version: 1.33.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1


### PR DESCRIPTION
The browser project added in #197 pointed only at Vue. React now gets the
same treatment, so the two most user-visible fixes in recent memory are
proven by symptom instead of by proxy:

- #191 (maxLength blocking input) was asserted by calling stripMaxLength
  directly, because jsdom reports ontouchstart and Inputmask clears the
  attribute itself there. Now a user types 11 digits into a cpf field that
  carries maxlength=11 and sees them. Reverting the fix fails the spec.
- #193 (onChange swallowed on the first delete) was asserted as ref call
  ordering. Now a predefined RHF value is selected, deleted and retyped,
  and the watch subscription has to see the first delete. Reversing the
  flow() argument order fails the spec.

Four specs under the existing browser project, no workflow changes:

- api/useMaskInput.browser.spec.ts — alias, raw pattern and pattern array
  through useMaskInput and withMask; maxLength; caret after a mid-value
  insert and after a re-render that leaves the mask unchanged
- api/useHookFormMask.browser.spec.ts — the #193 sequence and autoUnmask
  round trip through useHookFormMask and withHookFormMask
- api/useTanStackFormMask.browser.spec.ts — autoUnmask round trip against
  the real @tanstack/react-form, including the controlled re-render every
  keystroke triggers
- antd/useMaskInputAntd.browser.spec.ts — resolution through InputRef to
  the input inside antd's affix wrapper, and typing into it

Mounting goes through createRoot rather than a testing library, mirroring
how the Vue specs hand-roll createApp: these drive real Chromium events,
and an act environment would only add warnings around them.

Two notes for whoever writes the next one. userEvent.type, never
userEvent.fill — fill is a bulk value set and skips the per-keystroke
round trip. And leave a beat between focusing and the first keystroke,
because Inputmask repositions the caret on focus.

antd's Input is internally controlled and overwrites the value RHF writes
onto the DOM, mask or no mask, so its #193-style spec seeds the field by
typing rather than from defaultValues.

@tanstack/react-form joins devDependencies; the unit specs drive these
helpers with a hand-built inputProps object, which cannot show the
value-out/value-in loop a real field creates.

Closes #198

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KbbKWXa2NPhwpRcAs6gDFQ