### PR TITLE
fix: re-apply the mask when the mask or options change

### DIFF
--- a/.changeset/wise-pugs-shave.md
+++ b/.changeset/wise-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"use-mask-input": patch
+---
+
+`useMaskInput` now re-applies the mask when the mask or options change instead of keeping whichever one rendered first.

--- a/packages/use-mask-input/src/api/useMaskInput.browser.spec.ts
+++ b/packages/use-mask-input/src/api/useMaskInput.browser.spec.ts
@@ -258,4 +258,83 @@ describe('caret behaviour', () => {
     expect(displayed(input)).toBe(valueBefore);
     expect(input.selectionStart).toBe(4);
   });
+
+  it('keeps the caret when the options object is rebuilt with the same values', async () => {
+    let bump: (() => void) | undefined;
+
+    function Field() {
+      const [spare, setSpare] = useState(0);
+      // Fresh literal every render. Identity comparison would re-mask here.
+      const ref = useMaskInput({ mask: 'cpf', options: { placeholder: '_' } });
+      bump = () => setSpare((n) => n + 1);
+      return createElement('div', null, spare, createElement('input', { ref }));
+    }
+
+    const input = mount(createElement(Field));
+
+    await focus(input);
+    await userEvent.type(input, '12345678');
+
+    const valueBefore = displayed(input);
+    input.setSelectionRange(4, 4);
+
+    flushSync(() => { bump?.(); });
+    await nextFrame();
+
+    expect(displayed(input)).toBe(valueBefore);
+    expect(input.selectionStart).toBe(4);
+  });
+});
+
+/**
+ * The React counterpart of the Vue directive's `updated` hook. jsdom can only
+ * count calls into a mocked engine; formatting through the *new* mask needs the
+ * real one.
+ */
+describe('changing the mask after mount', () => {
+  function reactiveField(initial: Mask) {
+    let setMask: ((next: Mask) => void) | undefined;
+
+    function Field() {
+      const [mask, set] = useState<Mask>(initial);
+      const ref = useMaskInput({ mask });
+      setMask = set;
+      return createElement('input', { ref });
+    }
+
+    const input = mount(createElement(Field));
+
+    return {
+      input,
+      swap: (next: Mask) => {
+        flushSync(() => { setMask?.(next); });
+      },
+    };
+  }
+
+  it('formats through the new mask', async () => {
+    const { input, swap } = reactiveField('cpf');
+
+    swap('cnpj');
+    await nextFrame();
+
+    await focus(input);
+    await userEvent.type(input, '12345678000199');
+
+    // Still on cpf, this would stop after 11 digits as '123.456.780-00'.
+    expect(displayed(input)).toBe('12.345.678/0001-99');
+  });
+
+  it('stops masking when the mask becomes null', async () => {
+    const { input, swap } = reactiveField('cpf');
+
+    swap(null);
+    await nextFrame();
+
+    await focus(input);
+    await userEvent.type(input, 'hello');
+
+    // Under cpf the engine rejects every one of those characters.
+    expect(displayed(input)).toBe('hello');
+  });
 });

--- a/packages/use-mask-input/src/api/useMaskInput.spec.tsx
+++ b/packages/use-mask-input/src/api/useMaskInput.spec.tsx
@@ -9,7 +9,7 @@ import {
 import useMaskInput from './useMaskInput';
 import * as core from '../core';
 
-import type { Input } from '../types';
+import type { Input, Mask } from '../types';
 
 vi.mock('../core/inputmask', () => ({
   default: vi.fn((options) => ({
@@ -281,5 +281,142 @@ describe('useMaskInput', () => {
     rerender();
 
     expect(inputmask).toHaveBeenCalled();
+  });
+});
+
+/**
+ * The ref callback masks the element once, on attach, and its identity never
+ * changes, so a `mask` that depends on state used to be frozen at whatever
+ * rendered first: `useMaskInput({ mask: isCompany ? 'cnpj' : 'cpf' })` stayed on
+ * one of them forever.
+ *
+ * What these can prove here is which options reached Inputmask and how often.
+ * That the switched mask then formats the typed digits, and that an unchanged
+ * mask leaves the caret alone, needs a real engine and a real caret, so it lives
+ * in useMaskInput.browser.spec.ts.
+ */
+describe('useMaskInput reactivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(inputmask).mockReturnValue({ mask: vi.fn() } as any);
+  });
+
+  it('re-applies the mask when the mask changes', () => {
+    const input = document.createElement('input');
+
+    const { result, rerender } = renderHook(
+      ({ mask }) => useMaskInput({ mask }),
+      { initialProps: { mask: 'cpf' as Mask } },
+    );
+
+    act(() => {
+      result.current(input);
+    });
+
+    expect(inputmask).toHaveBeenCalledTimes(1);
+    vi.mocked(inputmask).mockClear();
+
+    rerender({ mask: 'cnpj' });
+
+    expect(inputmask).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(inputmask).mock.calls[0][0]).toMatchObject({
+      placeholder: '__.___.___/____-__',
+    });
+  });
+
+  it('re-applies when only the options change', () => {
+    const input = document.createElement('input');
+
+    const { result, rerender } = renderHook(
+      ({ prefix }) => useMaskInput({ mask: 'currency', options: { prefix } }),
+      { initialProps: { prefix: '$ ' } },
+    );
+
+    act(() => {
+      result.current(input);
+    });
+
+    vi.mocked(inputmask).mockClear();
+
+    rerender({ prefix: 'R$ ' });
+
+    expect(inputmask).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(inputmask).mock.calls[0][0]).toMatchObject({ prefix: 'R$ ' });
+  });
+
+  it('does not re-apply on an unrelated re-render', () => {
+    const input = document.createElement('input');
+
+    // The options literal is rebuilt every render, so identity comparison would
+    // see a change here and re-mask. Only a structural compare stays quiet.
+    const { result, rerender } = renderHook(
+      ({ spare }) => ({ spare, ref: useMaskInput({ mask: 'cpf', options: { placeholder: '_' } }) }),
+      { initialProps: { spare: 0 } },
+    );
+
+    act(() => {
+      result.current.ref(input);
+    });
+
+    vi.mocked(inputmask).mockClear();
+
+    rerender({ spare: 1 });
+    rerender({ spare: 2 });
+
+    expect(inputmask).not.toHaveBeenCalled();
+  });
+
+  it('does not re-apply on mount', () => {
+    const input = document.createElement('input');
+
+    const { result } = renderHook(() => useMaskInput({ mask: 'cpf' }));
+
+    act(() => {
+      result.current(input);
+    });
+
+    expect(inputmask).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the mask when the mask becomes null', () => {
+    const input = document.createElement('input');
+    const remove = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ mask }) => useMaskInput({ mask }),
+      { initialProps: { mask: 'cpf' as Mask } },
+    );
+
+    act(() => {
+      result.current(input);
+    });
+
+    input.inputmask = { remove } as any;
+    vi.mocked(inputmask).mockClear();
+
+    rerender({ mask: null });
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(inputmask).not.toHaveBeenCalled();
+  });
+
+  it('masks a late-attached element with the current mask, not the mount-time one', () => {
+    const input = document.createElement('input');
+
+    const { result, rerender } = renderHook(
+      ({ mask }) => useMaskInput({ mask }),
+      { initialProps: { mask: 'cpf' as Mask } },
+    );
+
+    rerender({ mask: 'cnpj' });
+    vi.mocked(inputmask).mockClear();
+
+    act(() => {
+      result.current(input);
+    });
+
+    expect(vi.mocked(inputmask).mock.calls[0][0]).toMatchObject({
+      placeholder: '__.___.___/____-__',
+    });
   });
 });

--- a/packages/use-mask-input/src/api/useMaskInput.ts
+++ b/packages/use-mask-input/src/api/useMaskInput.ts
@@ -2,10 +2,12 @@ import {
   useCallback, useEffect, useRef,
 } from 'react';
 
-import { resolveInputRef } from '../core';
+import { applyMaskToElement, resolveInputRef } from '../core';
 import withMask from './withMask';
 import isServer from '../utils/isServer';
-import { getUnmaskedValue, removeMask, setUnmaskedValue } from '../utils';
+import {
+  getUnmaskedValue, makeMaskCacheKey, removeMask, sameOptions, setUnmaskedValue,
+} from '../utils';
 
 import type {
   Input, Mask, Options, UseMaskInputReturn,
@@ -49,6 +51,39 @@ export default function useMaskInput(props: UseMaskInputOptions): UseMaskInputRe
     ref.current = resolveInputRef(input);
     withMask(maskRef.current, optionsRef.current)(ref.current);
   }, []);
+
+  /**
+   * `refCallback` masks the element once, on attach, and its identity is stable
+   * on purpose — so React never re-invokes it and a later `mask` or `options`
+   * would otherwise be ignored for the life of the component. This is the Vue
+   * directive's `updated` hook, minus the lifecycle React doesn't give us.
+   *
+   * The guard is the point: re-masking rebuilds Inputmask's buffer and sends the
+   * caret to the end, so an unrelated re-render must not reach the apply. Both
+   * comparisons are structural because callers pass inline literals.
+   */
+  useEffect(() => {
+    if (isServer) return;
+
+    const unchanged = makeMaskCacheKey('', maskRef.current) === makeMaskCacheKey('', mask)
+      && sameOptions(optionsRef.current, options);
+
+    // Keep the refs current either way: if the element re-attaches later,
+    // `refCallback` must mask it with the mask we have now, not the mount-time one.
+    maskRef.current = mask;
+    optionsRef.current = options;
+
+    if (unchanged || !ref.current) return;
+
+    // A null mask is not "do nothing" — it has to tear the old mask off, or the
+    // field keeps formatting after the caller switched masking off.
+    if (mask === null || mask === undefined) {
+      removeMask(ref.current);
+      return;
+    }
+
+    applyMaskToElement(ref.current, mask, options);
+  }, [mask, options]);
 
   useEffect(() => {
     if (isServer || !ref.current || !register) return;

--- a/packages/use-mask-input/src/utils/index.ts
+++ b/packages/use-mask-input/src/utils/index.ts
@@ -5,6 +5,7 @@ export {
   getUnmaskedValue,
   makeMaskCacheKey,
   removeMask,
+  sameOptions,
   setPrevRef,
   setUnmaskedValue,
 } from './maskHelpers';

--- a/packages/use-mask-input/src/utils/maskHelpers.ts
+++ b/packages/use-mask-input/src/utils/maskHelpers.ts
@@ -1,6 +1,8 @@
 import { findInputElement, resolveInputRef } from '../core/elementResolver';
 
-import type { Input, Mask, UnmaskedValueApi } from '../types';
+import type {
+  Input, Mask, Options, UnmaskedValueApi,
+} from '../types';
 
 // Kept self-contained (not relying on the ambient src/@types augmentation) so
 // this module type-checks when consumers compile the package source directly,
@@ -15,6 +17,30 @@ type MaskedElement = (HTMLInputElement | HTMLTextAreaElement) & {
  */
 export function makeMaskCacheKey(fieldName: string, mask: Mask): string {
   return `${fieldName}:${Array.isArray(mask) ? mask.join(',') : String(mask)}`;
+}
+
+/**
+ * Shallow equality over mask options. Shared by both binding layers so their
+ * "did this actually change?" guards cannot drift apart.
+ *
+ * Compares structurally, not by identity: callers pass inline object literals
+ * (`options={{ prefix: 'R$ ' }}`, `v-mask-input="{ mask: 'cpf' }"`) that
+ * allocate a fresh object every render and would otherwise never look equal.
+ *
+ * ponytail: shallow on purpose. An options object mutated in place, or one
+ * holding functions, won't compare equal-then-changed correctly — but deep
+ * comparison on every re-render is exactly the cost this guard exists to
+ * avoid. Documented as "replace options, don't mutate them".
+ */
+export function sameOptions(a?: Options, b?: Options): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+
+  const keysA = Object.keys(a) as (keyof Options)[];
+  const keysB = Object.keys(b) as (keyof Options)[];
+  if (keysA.length !== keysB.length) return false;
+
+  return keysA.every((key) => Object.is(a[key], b[key]));
 }
 
 /**

--- a/packages/use-mask-input/src/vue/applyMask.ts
+++ b/packages/use-mask-input/src/vue/applyMask.ts
@@ -1,5 +1,5 @@
 import { applyMaskToElement } from '../core';
-import { makeMaskCacheKey } from '../utils';
+import { makeMaskCacheKey, sameOptions } from '../utils';
 import isServer from '../utils/isServer';
 
 import type { Mask, Options, VueMaskBinding, VueMaskConfig } from './types';
@@ -32,25 +32,6 @@ export function normalizeBinding(binding: VueMaskBinding): {
   }
 
   return { mask: binding as Mask };
-}
-
-/**
- * Shallow equality over mask options.
- *
- * ponytail: shallow on purpose. An options object mutated in place, or one
- * holding functions, won't compare equal-then-changed correctly — but deep
- * comparison on every re-render is exactly the cost this guard exists to
- * avoid. Documented as "replace options, don't mutate them".
- */
-function sameOptions(a?: Options, b?: Options): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-
-  const keysA = Object.keys(a) as (keyof Options)[];
-  const keysB = Object.keys(b) as (keyof Options)[];
-  if (keysA.length !== keysB.length) return false;
-
-  return keysA.every((key) => Object.is(a[key], b[key]));
 }
 
 /**


### PR DESCRIPTION
## The bug

```tsx
const ref = useMaskInput({ mask: isCompany ? 'cnpj' : 'cpf' });
```

Toggle `isCompany` and nothing happens. The field keeps whichever mask was
active on the first render, for the life of the component.

`useMaskInput` captured `mask` and `options` into refs on first render
(`useRef(mask)`, `useRef(options)`) and gave `refCallback` an empty dep array.
Its identity never changed, so React never re-invoked it, and the refs it read
were still the mount-time values. Nothing in the hook ever looked at the new
mask.

Same failure for phone masks that switch by country, and for currency masks
that switch by locale.

## The fix

An effect re-applies the mask when the mask or the options actually change.

The guard is the interesting part. Re-masking rebuilds Inputmask's buffer and
moves the caret to the end of the value, so re-applying on every render would
break typing. Two things have to be true before the effect touches the element:

1. The mask key changed, built with the existing `makeMaskCacheKey`.
2. The options changed, compared structurally rather than by identity, because
   callers pass inline literals (`options={{ prefix: 'R$ ' }}`) that allocate a
   fresh object every render.

Mount is not a re-apply: `refCallback` already masked the element there, and the
refs still hold what it used, so the first effect run compares equal and returns.

A `null` mask removes the mask from the element instead of leaving the old one
formatting. The refs are also kept current either way, so an element that
re-attaches later gets the mask in effect now, not the mount-time one.

## The Vue surface already did this

`src/vue/directive.ts` has an `updated` hook with a `sameBinding` guard, so
`v-mask-input="on ? 'cpf' : null"` has always been reactive. This brings React
to the same semantics rather than inventing new ones. The shallow options
compare moved out of `src/vue/applyMask.ts` into `src/utils/maskHelpers.ts` so
there is one definition instead of two that can drift. No import crosses between
`src/api` and `src/vue`, and `scripts/assert-entry-isolation.mjs` still passes.

## Tests

jsdom (`useMaskInput.spec.tsx`) covers which options reach the engine and how
often: mask change re-applies, options-only change re-applies, unrelated
re-renders and mount do not, `null` calls `remove()`. Four of the six fail
without the fix; the other two are the regression guards.

Formatting through the new mask and caret preservation need a real engine and a
real caret, so those are in `useMaskInput.browser.spec.ts`: switch `cpf` to
`cnpj` and type a 14 digit document, switch to `null` and type letters, and a
caret check for a rebuilt options literal.

`test`, `test:browser`, `lint`, `type-check`, and `build` are green.

## Not in scope

`withMask` is untouched. Its callback cache is global and keyed by mask string,
so `currentInput` is shared across every component using the same mask. Making
it reactive is a riskier change and belongs on its own.
