### PR TITLE
feat: add cep, phone-br, date-br, time, credit-card and plate-br aliases

### DIFF
--- a/.changeset/add-br-mask-aliases.md
+++ b/.changeset/add-br-mask-aliases.md
@@ -1,0 +1,5 @@
+---
+"use-mask-input": minor
+---
+
+Add cep, phone-br, date-br, time, credit-card and br-plate built-in mask aliases.

--- a/.changeset/add-br-mask-aliases.md
+++ b/.changeset/add-br-mask-aliases.md
@@ -2,4 +2,4 @@
 "use-mask-input": minor
 ---
 
-Add cep, phone-br, date-br, time, credit-card and br-plate built-in mask aliases.
+Add cep, phone-br, date-br, time, credit-card and plate-br built-in mask aliases.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ There is deliberately no `<MaskInput>` component and no vee-validate helper, bec
 
 ## Built-in Aliases
 
-`cpf` · `cnpj` · `cep` · `phone-br` · `date-br` · `br-plate` · `br-bank-account` · `br-bank-agency` · `currency` · `brl-currency` · `credit-card` · `time` · `datetime` · `email` · `numeric` · `decimal` · `integer` · `percentage` · `url` · `ip` · `mac` · `ssn`
+`cpf` · `cnpj` · `cep` · `phone-br` · `date-br` · `plate-br` · `br-bank-account` · `br-bank-agency` · `currency` · `brl-currency` · `credit-card` · `time` · `datetime` · `email` · `numeric` · `decimal` · `integer` · `percentage` · `url` · `ip` · `mac` · `ssn`
 
 ## Works With
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ There is deliberately no `<MaskInput>` component and no vee-validate helper, bec
 
 ## Built-in Aliases
 
-`cpf` · `cnpj` · `br-bank-account` · `br-bank-agency` · `currency` · `brl-currency` · `datetime` · `email` · `numeric` · `decimal` · `integer` · `percentage` · `url` · `ip` · `mac` · `ssn`
+`cpf` · `cnpj` · `cep` · `phone-br` · `date-br` · `br-plate` · `br-bank-account` · `br-bank-agency` · `currency` · `brl-currency` · `credit-card` · `time` · `datetime` · `email` · `numeric` · `decimal` · `integer` · `percentage` · `url` · `ip` · `mac` · `ssn`
 
 ## Works With
 

--- a/packages/use-mask-input/src/core/maskConfig.spec.ts
+++ b/packages/use-mask-input/src/core/maskConfig.spec.ts
@@ -221,8 +221,8 @@ describe('maskConfig', () => {
       });
     });
 
-    it('returns options for br-plate mask', () => {
-      const options = getMaskOptions('br-plate');
+    it('returns options for plate-br mask', () => {
+      const options = getMaskOptions('plate-br');
       expect(options).toEqual({
         mask: ['AAA-9999', 'AAA9A99'],
         casing: 'upper',

--- a/packages/use-mask-input/src/core/maskConfig.spec.ts
+++ b/packages/use-mask-input/src/core/maskConfig.spec.ts
@@ -172,6 +172,65 @@ describe('maskConfig', () => {
       });
     });
 
+    it('returns options for cep mask', () => {
+      const options = getMaskOptions('cep');
+      expect(options).toEqual({
+        mask: '99999-999',
+        placeholder: '_____-___',
+        jitMasking: false,
+      });
+    });
+
+    it('returns options for phone-br mask', () => {
+      const options = getMaskOptions('phone-br');
+      expect(options).toEqual({
+        mask: ['(99) 9999-9999', '(99) 99999-9999'],
+        keepStatic: true,
+        placeholder: '',
+        jitMasking: false,
+      });
+    });
+
+    it('returns options for date-br mask', () => {
+      const options = getMaskOptions('date-br');
+      expect(options).toEqual({
+        alias: 'datetime',
+        inputFormat: 'dd/mm/yyyy',
+        placeholder: 'dd/mm/yyyy',
+        jitMasking: false,
+      });
+    });
+
+    it('returns options for time mask', () => {
+      const options = getMaskOptions('time');
+      expect(options).toEqual({
+        alias: 'datetime',
+        inputFormat: 'HH:mm',
+        placeholder: 'HH:mm',
+        jitMasking: false,
+      });
+    });
+
+    it('returns options for credit-card mask', () => {
+      const options = getMaskOptions('credit-card');
+      expect(options).toEqual({
+        mask: ['9999 999999 99999', '9999 9999 9999 9999'],
+        keepStatic: true,
+        placeholder: '',
+        jitMasking: false,
+      });
+    });
+
+    it('returns options for br-plate mask', () => {
+      const options = getMaskOptions('br-plate');
+      expect(options).toEqual({
+        mask: ['AAA-9999', 'AAA9A99'],
+        casing: 'upper',
+        placeholder: '',
+        jitMasking: false,
+      });
+    });
+
     it('returns custom mask string', () => {
       const options = getMaskOptions('999-999');
       expect(options).toEqual({
@@ -194,6 +253,16 @@ describe('maskConfig', () => {
       expect(options).toEqual({
         mask: '999.999.999-99',
         placeholder: '___',
+        jitMasking: false,
+      });
+    });
+
+    it('lets user options override the credit-card alias defaults', () => {
+      const options = getMaskOptions('credit-card', { keepStatic: false });
+      expect(options).toEqual({
+        mask: ['9999 999999 99999', '9999 9999 9999 9999'],
+        keepStatic: false,
+        placeholder: '',
         jitMasking: false,
       });
     });

--- a/packages/use-mask-input/src/core/maskConfig.ts
+++ b/packages/use-mask-input/src/core/maskConfig.ts
@@ -43,6 +43,24 @@ const ALIAS_MASKS: Record<string, InputmaskOptions> = {
     mask: '9{1,5}[-][9]', // Agency numbers: 1234, 12345, 1234-5
     placeholder: '',
   },
+  cep: { mask: '99999-999', placeholder: '_____-___' },
+  'phone-br': {
+    mask: ['(99) 9999-9999', '(99) 99999-9999'], // landline (8 digits) or mobile (9 digits)
+    keepStatic: true,
+    placeholder: '',
+  },
+  'date-br': { alias: 'datetime', inputFormat: 'dd/mm/yyyy', placeholder: 'dd/mm/yyyy' },
+  time: { alias: 'datetime', inputFormat: 'HH:mm', placeholder: 'HH:mm' },
+  'credit-card': {
+    mask: ['9999 999999 99999', '9999 9999 9999 9999'], // 15-digit (Amex) and 16-digit forms
+    keepStatic: true,
+    placeholder: '',
+  },
+  'br-plate': {
+    mask: ['AAA-9999', 'AAA9A99'], // old format and Mercosul format
+    casing: 'upper',
+    placeholder: '',
+  },
 };
 
 /**

--- a/packages/use-mask-input/src/core/maskConfig.ts
+++ b/packages/use-mask-input/src/core/maskConfig.ts
@@ -56,7 +56,7 @@ const ALIAS_MASKS: Record<string, InputmaskOptions> = {
     keepStatic: true,
     placeholder: '',
   },
-  'br-plate': {
+  'plate-br': {
     mask: ['AAA-9999', 'AAA9A99'], // old format and Mercosul format
     casing: 'upper',
     placeholder: '',

--- a/packages/use-mask-input/src/core/optionsPassthrough.spec.ts
+++ b/packages/use-mask-input/src/core/optionsPassthrough.spec.ts
@@ -109,4 +109,42 @@ describe('option behavior via the real engine (issue #192)', () => {
       expect(input.inputMode).toBe('numeric');
     });
   });
+
+  describe('new built-in aliases via the real engine', () => {
+    it('cep: formats a Brazilian postal code', () => {
+      expect(formatWithMask('01310100', 'cep')).toBe('01310-100');
+    });
+
+    it('phone-br: keepStatic picks the mobile (9-digit) form without getting stuck on the landline form', () => {
+      expect(formatWithMask('11987654321', 'phone-br')).toBe('(11) 98765-4321');
+    });
+
+    it('phone-br: still formats an 8-digit landline number', () => {
+      expect(formatWithMask('1198765432', 'phone-br')).toBe('(11) 9876-5432');
+    });
+
+    it('date-br: alias datetime + inputFormat dd/mm/yyyy', () => {
+      expect(formatWithMask('24072026', 'date-br')).toBe('24/07/2026');
+    });
+
+    it('time: alias datetime + inputFormat HH:mm (uppercase MM is month, not minutes)', () => {
+      expect(formatWithMask('1430', 'time')).toBe('14:30');
+    });
+
+    it('credit-card: keepStatic picks the 16-digit grouping', () => {
+      expect(formatWithMask('4111111111111111', 'credit-card')).toBe('4111 1111 1111 1111');
+    });
+
+    it('credit-card: keepStatic picks the 15-digit Amex grouping', () => {
+      expect(formatWithMask('378282246310005', 'credit-card')).toBe('3782 822463 10005');
+    });
+
+    it('br-plate: formats and upper-cases the old format', () => {
+      expect(formatWithMask('abc1234', 'br-plate')).toBe('ABC-1234');
+    });
+
+    it('br-plate: formats the Mercosul format', () => {
+      expect(formatWithMask('ABC1D23', 'br-plate')).toBe('ABC1D23');
+    });
+  });
 });

--- a/packages/use-mask-input/src/core/optionsPassthrough.spec.ts
+++ b/packages/use-mask-input/src/core/optionsPassthrough.spec.ts
@@ -139,12 +139,12 @@ describe('option behavior via the real engine (issue #192)', () => {
       expect(formatWithMask('378282246310005', 'credit-card')).toBe('3782 822463 10005');
     });
 
-    it('br-plate: formats and upper-cases the old format', () => {
-      expect(formatWithMask('abc1234', 'br-plate')).toBe('ABC-1234');
+    it('plate-br: formats and upper-cases the old format', () => {
+      expect(formatWithMask('abc1234', 'plate-br')).toBe('ABC-1234');
     });
 
-    it('br-plate: formats the Mercosul format', () => {
-      expect(formatWithMask('ABC1D23', 'br-plate')).toBe('ABC1D23');
+    it('plate-br: formats the Mercosul format', () => {
+      expect(formatWithMask('ABC1D23', 'plate-br')).toBe('ABC1D23');
     });
   });
 });

--- a/packages/use-mask-input/src/types/mask.ts
+++ b/packages/use-mask-input/src/types/mask.ts
@@ -24,6 +24,12 @@ export type Mask = 'datetime'
   | 'cnpj'
   | 'br-bank-account'
   | 'br-bank-agency'
+  | 'cep'
+  | 'phone-br'
+  | 'date-br'
+  | 'time'
+  | 'credit-card'
+  | 'br-plate'
   | (string & {})
   | (string[] & {})
   | null;

--- a/packages/use-mask-input/src/types/mask.ts
+++ b/packages/use-mask-input/src/types/mask.ts
@@ -29,7 +29,7 @@ export type Mask = 'datetime'
   | 'date-br'
   | 'time'
   | 'credit-card'
-  | 'br-plate'
+  | 'plate-br'
   | (string & {})
   | (string[] & {})
   | null;


### PR DESCRIPTION
## Summary

The library already ships cpf, cnpj and brl-currency for Brazilian forms but had no postal code, phone, date or plate alias. This adds six built-in mask aliases to core/maskConfig.ts:

| alias | pattern | note |
|---|---|---|
| cep | 99999-999 | Brazilian postal code |
| phone-br | (99) 9999-9999 or (99) 99999-9999 | landline or mobile, keepStatic true so the 8-digit mask does not block a 9-digit number |
| date-br | dd/mm/yyyy | alias: datetime with inputFormat, so date validation comes from inputmask instead of a raw digit pattern |
| time | HH:mm | same approach as date-br. Note lowercase mm: inputmask reserves uppercase MM for month, so HH:MM silently parses minutes as month and mangles the value |
| credit-card | 9999 999999 99999 or 9999 9999 9999 9999 | 15-digit Amex and 16-digit forms, keepStatic true. The Amex pattern has to come first in the array or a 15-digit number gets formatted against the 16-digit mask instead |
| plate-br | AAA-9999 or AAA9A99 | old and Mercosul plate formats, casing: upper |

## Why

This is a Brazil-focused library that already covers cpf, cnpj and brl-currency. cep, phone and plate are the other everyday BR form fields, and date-br/time round out generic formats reused across both React and Vue since the alias table lives in the shared core.

## Test plan
- [x] `pnpm --filter=use-mask-input test` (273 passed, including new getMaskOptions cases and real-engine formatting cases for all six aliases)
- [x] `pnpm --filter=use-mask-input lint`
- [x] `pnpm --filter=use-mask-input type-check`
