### PR TITLE
fix: remove the mask when the React ref detaches

### DIFF
--- a/.changeset/react-mask-teardown.md
+++ b/.changeset/react-mask-teardown.md
@@ -1,0 +1,5 @@
+---
+"use-mask-input": patch
+---
+
+Remove Inputmask from the element when a React ref detaches, instead of leaving its listeners and value accessor behind.

--- a/packages/use-mask-input/src/antd/useHookFormMaskAntd.ts
+++ b/packages/use-mask-input/src/antd/useHookFormMaskAntd.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { applyMaskToElement, resolveInputRef } from '../core';
-import { makeMaskCacheKey, setPrevRef } from '../utils';
+import { makeMaskCacheKey, removeMask, setPrevRef } from '../utils';
 
 import type { InputRef } from 'antd';
 import type { RefCallback } from 'react';
@@ -45,8 +45,14 @@ export default function useHookFormMaskAntd<
       const cacheKey = makeMaskCacheKey(fieldName, mask);
 
       if (!refCache.has(cacheKey)) {
+        // antd hands back an InputRef, so the detach call carries no element to
+        // unmask. Remember the one we masked.
+        let maskedElement: HTMLElement | null = null;
+
         const refWithMask: RefCallback<InputRef | null> = (inputRef) => {
           const element = inputRef ? resolveInputRef(inputRef.input) : null;
+          if (!element) removeMask(maskedElement);
+          maskedElement = element;
           if (element) applyMaskToElement(element, mask, options as Options);
           if (ref) ref(element);
         };

--- a/packages/use-mask-input/src/antd/useMaskInputAntd.ts
+++ b/packages/use-mask-input/src/antd/useMaskInputAntd.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import withMask from '../api/withMask';
 import { resolveInputRef } from '../core';
 import isServer from '../utils/isServer';
-import { getUnmaskedValue, setUnmaskedValue } from '../utils';
+import { getUnmaskedValue, removeMask, setUnmaskedValue } from '../utils';
 
 import type { InputRef } from 'antd';
 
@@ -39,6 +39,8 @@ export default function useMaskInputAntd(props: UseMaskInputOptions): UseMaskInp
 
   const refCallback = useCallback((input: InputRef | null): void => {
     if (!input) {
+      removeMask(maskedElementRef.current);
+      maskedElementRef.current = null;
       ref.current = null;
       return;
     }

--- a/packages/use-mask-input/src/api/useHookFormMask.ts
+++ b/packages/use-mask-input/src/api/useHookFormMask.ts
@@ -2,7 +2,7 @@ import { useLayoutEffect, useMemo, useRef } from 'react';
 
 import { applyMaskToElement } from '../core';
 import {
-  flow, getUnmaskedValue, makeMaskCacheKey, setPrevRef, setUnmaskedValue,
+  flow, getUnmaskedValue, makeMaskCacheKey, removeMask, setPrevRef, setUnmaskedValue,
 } from '../utils';
 
 import type { RefCallback } from 'react';
@@ -74,6 +74,7 @@ export default function useHookFormMask<
         };
 
         const applyMaskToRef = (_ref: HTMLElement | null) => {
+          if (!_ref) removeMask(nextEntry.element);
           nextEntry.element = _ref;
           if (_ref) applyMaskToElement(_ref, mask, options as Options);
           return _ref;

--- a/packages/use-mask-input/src/api/useMaskInput.browser.spec.ts
+++ b/packages/use-mask-input/src/api/useMaskInput.browser.spec.ts
@@ -47,11 +47,13 @@ function mount(element: ReactElement): HTMLInputElement {
   return input;
 }
 
-afterEach(() => {
+function unmountActive(): void {
   active?.root.unmount();
   active?.host.remove();
   active = null;
-});
+}
+
+afterEach(unmountActive);
 
 /**
  * The text the user actually sees.
@@ -174,6 +176,45 @@ describe('maxLength on a masked input (#191)', () => {
     const input = renderHooked('numeric', undefined, { maxLength: 5 });
 
     expect(input.getAttribute('maxlength')).toBe('5');
+  });
+});
+
+describe('teardown when the ref detaches', () => {
+  /**
+   * jsdom can only show that `remove()` was called on a stub. What the leak
+   * actually was, listeners still bound and the `value` property still pointing
+   * at Inputmask's accessor instead of the native one, is only observable
+   * against a real DOM.
+   */
+  it('gives the element its native value accessor back on unmount', async () => {
+    const input = renderHooked('cpf');
+    const native = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+
+    await focus(input);
+    await userEvent.type(input, '12345678901');
+
+    expect(input.inputmask).toBeDefined();
+    expect(Object.getOwnPropertyDescriptor(input, 'value')?.get).not.toBe(native?.get);
+
+    unmountActive();
+
+    expect(input.inputmask).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(input, 'value')?.get).toBe(native?.get);
+  });
+
+  it('masks a fresh element after the previous one was torn down', async () => {
+    const first = renderHooked('cpf');
+    await focus(first);
+    await userEvent.type(first, '12345678901');
+    expect(displayed(first)).toBe('123.456.789-01');
+
+    unmountActive();
+
+    const second = renderHooked('cpf');
+    await focus(second);
+    await userEvent.type(second, '98765432100');
+
+    expect(displayed(second)).toBe('987.654.321-00');
   });
 });
 

--- a/packages/use-mask-input/src/api/useMaskInput.spec.tsx
+++ b/packages/use-mask-input/src/api/useMaskInput.spec.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
+import { createElement } from 'react';
 import inputmask from '../core/inputmask';
 import {
   beforeEach,
@@ -217,6 +218,52 @@ describe('useMaskInput', () => {
     rerender();
 
     expect(inputmask).toHaveBeenCalled();
+  });
+
+  it('removes the mask when React detaches the ref', () => {
+    const remove = vi.fn();
+    vi.mocked(inputmask).mockReturnValue({
+      mask: vi.fn((element: HTMLInputElement) => {
+        const target = element;
+        target.inputmask = { remove } as never;
+      }),
+    } as any);
+
+    function Field() {
+      const ref = useMaskInput({ mask: '99-99' });
+      return createElement('input', { ref });
+    }
+
+    const { unmount } = render(createElement(Field));
+    expect(remove).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('masks the new element after a teardown and remount', () => {
+    const masked: HTMLElement[] = [];
+    const remove = vi.fn();
+    vi.mocked(inputmask).mockReturnValue({
+      mask: vi.fn((element: HTMLInputElement) => {
+        const target = element;
+        masked.push(target);
+        target.inputmask = { remove } as never;
+      }),
+    } as any);
+
+    function Field() {
+      const ref = useMaskInput({ mask: '999-99' });
+      return createElement('input', { ref });
+    }
+
+    render(createElement(Field)).unmount();
+    render(createElement(Field)).unmount();
+
+    expect(masked).toHaveLength(2);
+    expect(masked[0]).not.toBe(masked[1]);
+    expect(remove).toHaveBeenCalledTimes(2);
   });
 
   it('handles case where findInputElement returns valid element', () => {

--- a/packages/use-mask-input/src/api/useMaskInput.ts
+++ b/packages/use-mask-input/src/api/useMaskInput.ts
@@ -5,7 +5,7 @@ import {
 import { resolveInputRef } from '../core';
 import withMask from './withMask';
 import isServer from '../utils/isServer';
-import { getUnmaskedValue, setUnmaskedValue } from '../utils';
+import { getUnmaskedValue, removeMask, setUnmaskedValue } from '../utils';
 
 import type {
   Input, Mask, Options, UseMaskInputReturn,
@@ -36,6 +36,12 @@ export default function useMaskInput(props: UseMaskInputOptions): UseMaskInputRe
 
   const refCallback = useCallback((input: Input | null): void => {
     if (!input) {
+      // React hands us `null` when the ref comes off the element, which is not
+      // always an unmount: the element can outlive the detach, or be handed to
+      // a different ref. Leaving Inputmask attached leaves its listeners and its
+      // `value` accessor on it. See `removeMask` for why the teardown lives here
+      // and not in a React 19 cleanup return.
+      removeMask(ref.current);
       ref.current = null;
       return;
     }

--- a/packages/use-mask-input/src/api/withHookFormMask.ts
+++ b/packages/use-mask-input/src/api/withHookFormMask.ts
@@ -1,6 +1,6 @@
 import { applyMaskToElement } from '../core';
 import {
-  getUnmaskedValue, makeMaskCacheKey, setPrevRef, setUnmaskedValue,
+  getUnmaskedValue, makeMaskCacheKey, removeMask, setPrevRef, setUnmaskedValue,
 } from '../utils';
 
 import type { RefCallback } from 'react';
@@ -55,6 +55,7 @@ export default function withHookFormMask(
 
   if (!maskCache?.has(cacheKey)) {
     const maskedRef = ((input: HTMLElement | null) => {
+      if (!input) removeMask(maskedRef.currentElement ?? null);
       maskedRef.currentElement = input;
       if (input) applyMaskToElement(input, mask, options);
       return ref(input);

--- a/packages/use-mask-input/src/api/withTanStackFormMask.ts
+++ b/packages/use-mask-input/src/api/withTanStackFormMask.ts
@@ -1,6 +1,6 @@
 import { applyMaskToElement } from '../core';
 import {
-  getUnmaskedValue, makeMaskCacheKey, setPrevRef, setUnmaskedValue,
+  getUnmaskedValue, makeMaskCacheKey, removeMask, setPrevRef, setUnmaskedValue,
 } from '../utils';
 
 import type { RefCallback } from 'react';
@@ -34,6 +34,7 @@ export default function withTanStackFormMask<T extends TanStackFormInputProps>(
     const result = {
       ...inputProps,
       ref: ((input: HTMLElement | null) => {
+        if (!input) removeMask(currentElement);
         currentElement = input;
         if (input) applyMaskToElement(input, mask, options);
       }) as RefCallback<HTMLElement | null>,
@@ -53,6 +54,7 @@ export default function withTanStackFormMask<T extends TanStackFormInputProps>(
 
   if (!maskCache?.has(cacheKey)) {
     const maskedRef = ((input: HTMLElement | null) => {
+      if (!input) removeMask(maskedRef.currentElement ?? null);
       maskedRef.currentElement = input;
       if (input) applyMaskToElement(input, mask, options);
       ref(input);

--- a/packages/use-mask-input/src/utils/index.ts
+++ b/packages/use-mask-input/src/utils/index.ts
@@ -4,6 +4,7 @@ export { default as moduleInterop } from './moduleInterop';
 export {
   getUnmaskedValue,
   makeMaskCacheKey,
+  removeMask,
   setPrevRef,
   setUnmaskedValue,
 } from './maskHelpers';

--- a/packages/use-mask-input/src/utils/maskHelpers.ts
+++ b/packages/use-mask-input/src/utils/maskHelpers.ts
@@ -6,7 +6,7 @@ import type { Input, Mask, UnmaskedValueApi } from '../types';
 // this module type-checks when consumers compile the package source directly,
 // e.g. the example apps that alias `use-mask-input` to `src` and build with `tsc`.
 type MaskedElement = (HTMLInputElement | HTMLTextAreaElement) & {
-  inputmask?: { unmaskedvalue?: () => string };
+  inputmask?: { unmaskedvalue?: () => string; remove?: () => void };
 };
 
 /**
@@ -53,6 +53,25 @@ export function getUnmaskedValue(input: Input | null): string {
   }
 
   return 'value' in element ? element.value : '';
+}
+
+/**
+ * Detaches Inputmask from an element, restoring the native `value` accessor it
+ * overrode and dropping the listeners it installed.
+ *
+ * Every React ref callback in this package calls this from its detach branch,
+ * rather than returning a cleanup function. React 19 added cleanup returns, but
+ * React 17 and 18 ignore whatever a ref callback returns, so on the lower half
+ * of the `react >= 17` peer range the cleanup would silently never run. The
+ * detach branch is correct on all three: 17 and 18 always call `ref(null)` when
+ * the ref comes off an element, and 19 still does for any callback that returns
+ * no cleanup, which these do since they return void.
+ *
+ * @param input - The element (or ref) the mask was applied to
+ */
+export function removeMask(input: Input | null): void {
+  const element = resolveUnmaskedInput(input) as MaskedElement | null;
+  element?.inputmask?.remove?.();
 }
 
 export function setUnmaskedValue<T extends object>(

--- a/packages/use-mask-input/src/vue/directive.ts
+++ b/packages/use-mask-input/src/vue/directive.ts
@@ -13,8 +13,8 @@ type MaskedElement = HTMLElement & {
  * `v-mask-input` — the only thing in the Vue entry that applies a mask.
  *
  * Getting real lifecycle hooks is why this, and not the composable, is the
- * primitive: the React surface has no equivalent of `unmounted`, which is why
- * it never tears Inputmask down.
+ * primitive. The React surface has no `unmounted`, so it tears Inputmask down
+ * from the detach branch of its ref callbacks instead (see `utils/removeMask`).
  *
  * Note there is no `v-model` handling here, and none is needed. Inputmask
  * replaces the element's `value` property with its own accessor, so `v-model`


### PR DESCRIPTION
## What leaked

Every React ref callback in the package handled `ref(null)` by clearing its own
element reference and nothing else. Inputmask stayed attached to the element:
its event listeners were still bound, and the `value` property it had redefined
on the element still pointed at the engine's accessor instead of the native one.

The Vue directive already tore down in `unmounted`. Its doc comment said in so
many words that the React side never did. That comment is now accurate.

Unmount is the obvious case, but not the only one. React calls `ref(null)`
whenever a ref comes off an element, and the element can outlive that: a
conditional ref, a ref swapped to another callback, an element pulled out and
reused. Those all left a masked element behind.

## React 17/18 vs 19

React 19 lets a ref callback return a cleanup function, and when one is
returned it skips the `ref(null)` call. That is the natural place for this, and
it is the wrong one here. The peer range is `react >= 17`, and 17 and 18 ignore
a ref callback's return value entirely, so the cleanup would silently never run
on either of them.

So the teardown lives in the `null` branch instead. That is correct on all
three: 17 and 18 always call `ref(null)` on detach, and 19 still does for any
callback that returns no cleanup, which these do since they return void. The
reasoning is written out on `removeMask` in `src/utils/maskHelpers.ts`.
`useHookFormMask` already had a comment about the same constraint from the
other direction (its composed ref must not accidentally return the element).

## Coverage

`removeMask(input)` resolves the element the way the apply path does, so it
finds the inner `<input>` inside a wrapper, then calls `inputmask?.remove?.()`.
Guarded because the property is absent on anything never masked.

Called from the detach branch of:

- `api/useMaskInput`
- `api/useHookFormMask`
- `api/withHookFormMask`
- `api/withTanStackFormMask`
- `antd/useMaskInputAntd`
- `antd/useHookFormMaskAntd` (this one kept no element reference, so it now
  remembers the one it masked; the antd detach call carries an `InputRef` of
  `null` and no element)

`useTanStackFormMask` delegates to `withTanStackFormMask`, so it is covered by
that one.

## withMask is deliberately untouched

`api/withMask.ts` caches its callbacks in a module-level map keyed by mask
string, so two components using `withMask('cpf')` share one callback and one
`currentInput`. Calling `remove()` from that callback would tear the mask off
whichever element wrote `currentInput` last, which can be a different component
still mounted. Fixing it means giving the cached callback per-element state, or
dropping the cache. Left open.

## Tests

`useMaskInput.spec.tsx` (jsdom): mount and unmount through
`@testing-library/react`, assert `remove()` ran once on detach, and that a
remount masks a second, different element. jsdom can only prove the call
against a stub, since the suite mocks the engine.

`useMaskInput.browser.spec.ts` (chromium): the real assertion. After typing into
a `cpf` field and unmounting, `input.inputmask` is `undefined` and the element's
own `value` descriptor getter is back to `HTMLInputElement.prototype`'s. Plus a
second field masking correctly after the first was torn down.

Both new jsdom tests and the accessor test fail without the fix. Checked.
