### PR TITLE
feat: expose isComplete, isValidWithMask and getUnmaskedValue

### DIFF
--- a/.changeset/expose-completeness-and-unmasked-helpers.md
+++ b/.changeset/expose-completeness-and-unmasked-helpers.md
@@ -1,0 +1,7 @@
+---
+"use-mask-input": minor
+---
+
+Add `isComplete()` next to `unmaskedValue()` on every hook and `with*` return (React and Vue), plus three standalone helpers: `isValidWithMask(value, mask)` for schema validators, `getUnmaskedValue(element)` for reading the raw value from `event.target`, and `isMaskComplete(element)`.
+
+`useHookFormMaskAntd` now actually carries `unmaskedValue()` and `isComplete()`; its return type always promised them.

--- a/README.md
+++ b/README.md
@@ -218,8 +218,18 @@ There is deliberately no `<MaskInput>` component and no vee-validate helper, bec
 | `useHookFormMaskAntd` | Hook. `useHookFormMask` for Ant Design. |
 | `formatWithMask` | Function. Formats a raw value using a mask, without a mounted element. |
 | `unformatWithMask` | Function. Removes the mask from a formatted value, without a mounted element. |
+| `isValidWithMask` | Function. Whether a value is a complete, valid entry for a mask. For schema validators. |
+| `getUnmaskedValue` | Function. Reads the unmasked value off an element, e.g. `event.target` in `onChange`. |
+| `isMaskComplete` | Function. Whether the mask on an element is fully filled. |
 | `vMaskInput` | Vue directive. `use-mask-input/vue`. The Vue default choice. |
-| `useMaskInput` (Vue) | Composable. `use-mask-input/vue`. Returns `{ maskRef, unmaskedValue }`. |
+| `useMaskInput` (Vue) | Composable. `use-mask-input/vue`. Returns `{ maskRef, unmaskedValue, isComplete }`. |
+
+Every hook and `with*` helper also carries `unmaskedValue()` and `isComplete()` on what it returns:
+
+```tsx
+const cpf = useMaskInput({ mask: 'cpf' });
+<input ref={cpf} onChange={(e) => console.log(getUnmaskedValue(e.target), cpf.isComplete())} />
+```
 
 ## Built-in Aliases
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ There is deliberately no `<MaskInput>` component and no vee-validate helper, bec
 | `useHookFormMaskAntd` | Hook. `useHookFormMask` for Ant Design. |
 | `formatWithMask` | Function. Formats a raw value using a mask, without a mounted element. |
 | `unformatWithMask` | Function. Removes the mask from a formatted value, without a mounted element. |
-| `isValidWithMask` | Function. Whether a value is a complete, valid entry for a mask. For schema validators. |
+| `isValidWithMask` | Function. Whether a value, masked or raw, is a complete valid entry for a mask. For schema validators. |
 | `getUnmaskedValue` | Function. Reads the unmasked value off an element, e.g. `event.target` in `onChange`. |
 | `isMaskComplete` | Function. Whether the mask on an element is fully filled. |
 | `vMaskInput` | Vue directive. `use-mask-input/vue`. The Vue default choice. |

--- a/packages/use-mask-input/README.md
+++ b/packages/use-mask-input/README.md
@@ -218,8 +218,18 @@ There is deliberately no `<MaskInput>` component and no vee-validate helper, bec
 | `useHookFormMaskAntd` | Hook. `useHookFormMask` for Ant Design. |
 | `formatWithMask` | Function. Formats a raw value using a mask, without a mounted element. |
 | `unformatWithMask` | Function. Removes the mask from a formatted value, without a mounted element. |
+| `isValidWithMask` | Function. Whether a value is a complete, valid entry for a mask. For schema validators. |
+| `getUnmaskedValue` | Function. Reads the unmasked value off an element, e.g. `event.target` in `onChange`. |
+| `isMaskComplete` | Function. Whether the mask on an element is fully filled. |
 | `vMaskInput` | Vue directive. `use-mask-input/vue`. The Vue default choice. |
-| `useMaskInput` (Vue) | Composable. `use-mask-input/vue`. Returns `{ maskRef, unmaskedValue }`. |
+| `useMaskInput` (Vue) | Composable. `use-mask-input/vue`. Returns `{ maskRef, unmaskedValue, isComplete }`. |
+
+Every hook and `with*` helper also carries `unmaskedValue()` and `isComplete()` on what it returns:
+
+```tsx
+const cpf = useMaskInput({ mask: 'cpf' });
+<input ref={cpf} onChange={(e) => console.log(getUnmaskedValue(e.target), cpf.isComplete())} />
+```
 
 ## Built-in Aliases
 

--- a/packages/use-mask-input/README.md
+++ b/packages/use-mask-input/README.md
@@ -218,7 +218,7 @@ There is deliberately no `<MaskInput>` component and no vee-validate helper, bec
 | `useHookFormMaskAntd` | Hook. `useHookFormMask` for Ant Design. |
 | `formatWithMask` | Function. Formats a raw value using a mask, without a mounted element. |
 | `unformatWithMask` | Function. Removes the mask from a formatted value, without a mounted element. |
-| `isValidWithMask` | Function. Whether a value is a complete, valid entry for a mask. For schema validators. |
+| `isValidWithMask` | Function. Whether a value, masked or raw, is a complete valid entry for a mask. For schema validators. |
 | `getUnmaskedValue` | Function. Reads the unmasked value off an element, e.g. `event.target` in `onChange`. |
 | `isMaskComplete` | Function. Whether the mask on an element is fully filled. |
 | `vMaskInput` | Vue directive. `use-mask-input/vue`. The Vue default choice. |

--- a/packages/use-mask-input/src/@types/inputmask.d.ts
+++ b/packages/use-mask-input/src/@types/inputmask.d.ts
@@ -11,6 +11,8 @@
 
 interface InputmaskInstance {
   unmaskedvalue?: () => string;
+  /** True once every required mask position is filled; `undefined` for `repeat: '*'`. */
+  isComplete?: () => boolean | undefined;
   /** Resolved configuration, after alias defaults are merged with user options. */
   opts?: Record<string, unknown>;
   /** Detaches the mask from its element. Used by the Vue directive on unmount. */

--- a/packages/use-mask-input/src/antd/useHookFormMaskAntd.ts
+++ b/packages/use-mask-input/src/antd/useHookFormMaskAntd.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 
 import { applyMaskToElement, resolveInputRef } from '../core';
-import { makeMaskCacheKey, removeMask, setPrevRef } from '../utils';
+import {
+  makeMaskCacheKey, removeMask, setPrevRef, setValueApi,
+} from '../utils';
 
 import type { InputRef } from 'antd';
 import type { RefCallback } from 'react';
@@ -12,6 +14,10 @@ import type {
 } from 'react-hook-form';
 
 import type { Mask, Options, UseHookFormMaskReturn } from '../types';
+
+type MaskedRefCallback = RefCallback<InputRef | null> & {
+  currentElement?: HTMLElement | null;
+};
 
 export type UseHookFormMaskAntdReturn<T extends FieldValues> = Omit<
   UseHookFormMaskReturn<T>,
@@ -33,7 +39,7 @@ export default function useHookFormMaskAntd<
   D & Options) | Options | D) => UseHookFormMaskAntdReturn<T>) {
   //
   return useMemo(() => {
-    const refCache = new Map<string, RefCallback<InputRef | null>>();
+    const refCache = new Map<string, MaskedRefCallback>();
 
     return (fieldName: Path<T>, mask: Mask, options?: (
       D & Options) | Options | D): UseHookFormMaskAntdReturn<T> => {
@@ -49,20 +55,23 @@ export default function useHookFormMaskAntd<
         // unmask. Remember the one we masked.
         let maskedElement: HTMLElement | null = null;
 
-        const refWithMask: RefCallback<InputRef | null> = (inputRef) => {
+        const refWithMask: MaskedRefCallback = (inputRef) => {
           const element = inputRef ? resolveInputRef(inputRef.input) : null;
           if (!element) removeMask(maskedElement);
           maskedElement = element;
+          refWithMask.currentElement = element;
           if (element) applyMaskToElement(element, mask, options as Options);
           if (ref) ref(element);
         };
         refCache.set(cacheKey, refWithMask);
       }
 
+      const maskedRef = refCache.get(cacheKey);
       const result = {
         ...registerReturn,
-        ref: refCache.get(cacheKey),
+        ref: maskedRef,
       } as UseHookFormMaskAntdReturn<T>;
+      setValueApi(result, () => maskedRef?.currentElement ?? null);
 
       setPrevRef(result, ref);
 

--- a/packages/use-mask-input/src/antd/useMaskInputAntd.browser.spec.ts
+++ b/packages/use-mask-input/src/antd/useMaskInputAntd.browser.spec.ts
@@ -127,15 +127,14 @@ describe('useMaskInputAntd', () => {
 describe('useHookFormMaskAntd', () => {
   it('round trips autoUnmask through an antd-wrapped field', async () => {
     let form: UseFormReturn<Values> | undefined;
+    let field: ReturnType<ReturnType<typeof useHookFormMaskAntd<Values, never>>> | undefined;
 
     function Form() {
       const api = useForm<Values>({ defaultValues: { cpf: '' } });
       form = api;
       const registerWithMask = useHookFormMaskAntd(api.register);
-      return createElement(Input, {
-        ...registerWithMask('cpf', 'cpf', { autoUnmask: true }),
-        prefix: '#',
-      });
+      field = registerWithMask('cpf', 'cpf', { autoUnmask: true });
+      return createElement(Input, { ...field, prefix: '#' });
     }
 
     const input = mount(createElement(Form));
@@ -145,6 +144,8 @@ describe('useHookFormMaskAntd', () => {
 
     expect(displayed(input)).toBe('123.456.789-01');
     expect(form?.getValues('cpf')).toBe(CPF);
+    expect(field?.unmaskedValue()).toBe(CPF);
+    expect(field?.isComplete()).toBe(true);
   });
 
   it('registers the first delete after the user fills the field', async () => {

--- a/packages/use-mask-input/src/antd/useMaskInputAntd.ts
+++ b/packages/use-mask-input/src/antd/useMaskInputAntd.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import withMask from '../api/withMask';
 import { resolveInputRef } from '../core';
 import isServer from '../utils/isServer';
-import { getUnmaskedValue, removeMask, setUnmaskedValue } from '../utils';
+import { removeMask, setValueApi } from '../utils';
 
 import type { InputRef } from 'antd';
 
@@ -32,7 +32,6 @@ export default function useMaskInputAntd(props: UseMaskInputOptions): UseMaskInp
   const maskRef = useRef(mask);
   const optionsRef = useRef(options);
   const maskedElementRef = useRef<HTMLInputElement | null>(null);
-  const unmaskedValue = useCallback(() => getUnmaskedValue(ref.current), []);
 
   maskRef.current = mask;
   optionsRef.current = options;
@@ -63,8 +62,8 @@ export default function useMaskInputAntd(props: UseMaskInputOptions): UseMaskInp
       // server doesn't have dom, so just do nothing
     }) as unknown as UseMaskInputAntdReturn;
 
-    return setUnmaskedValue(noop, () => '');
+    return setValueApi(noop, () => null);
   }
 
-  return setUnmaskedValue(refCallback as UseMaskInputAntdReturn, unmaskedValue);
+  return setValueApi(refCallback as UseMaskInputAntdReturn, () => ref.current);
 }

--- a/packages/use-mask-input/src/api/completeness.browser.spec.ts
+++ b/packages/use-mask-input/src/api/completeness.browser.spec.ts
@@ -1,0 +1,154 @@
+/* eslint-disable import-x/no-extraneous-dependencies */
+import { userEvent } from '@vitest/browser/context';
+import { createElement, useState } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { useForm } from 'react-hook-form';
+import {
+  afterEach, describe, expect, it,
+} from 'vitest';
+
+import useHookFormMask from './useHookFormMask';
+import useMaskInput from './useMaskInput';
+import withMask from './withMask';
+import { getUnmaskedValue } from '../utils';
+
+import type { ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+import type { Mask, UseMaskInputReturn } from '../types';
+
+/**
+ * `isComplete()` and `getUnmaskedValue()` driven by a keyboard, at the hook
+ * level: partial, complete, cleared, mask switched off, element gone.
+ */
+
+let active: { root: Root; host: HTMLDivElement } | null = null;
+
+function mount(element: ReactElement): HTMLInputElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  flushSync(() => { root.render(element); });
+  active = { root, host };
+  const input = host.querySelector('input');
+  if (!input) throw new Error('no input rendered');
+  return input;
+}
+
+afterEach(() => {
+  active?.root.unmount();
+  active?.host.remove();
+  active = null;
+});
+
+const nextFrame = () => new Promise((resolve) => { requestAnimationFrame(() => resolve(null)); });
+async function focus(el: HTMLInputElement) { await userEvent.click(el); await nextFrame(); }
+
+const CPF = '12345678901';
+
+let api: UseMaskInputReturn | undefined;
+let setMask: (mask: Mask) => void = () => {};
+
+function renderHooked(initialMask: Mask = 'cpf') {
+  function Field() {
+    const [mask, set] = useState<Mask>(initialMask);
+    setMask = (next) => flushSync(() => set(next));
+    api = useMaskInput({ mask });
+    return createElement('input', { ref: api });
+  }
+  return mount(createElement(Field));
+}
+
+describe('isComplete() through useMaskInput', () => {
+  it('follows the keyboard: false, then true, then false again', async () => {
+    const input = renderHooked();
+    expect(api?.isComplete()).toBe(false);
+
+    await focus(input);
+    await userEvent.keyboard('12345');
+    expect(api?.isComplete()).toBe(false);
+    expect(api?.unmaskedValue()).toBe('12345');
+
+    await userEvent.keyboard('678901');
+    expect(api?.isComplete()).toBe(true);
+
+    input.select();
+    await userEvent.keyboard('{Delete}');
+    expect(api?.isComplete()).toBe(false);
+    expect(api?.unmaskedValue()).toBe('');
+  });
+
+  it('reads true once the mask is switched off, and false once the element is gone', async () => {
+    const input = renderHooked();
+    await focus(input);
+    await userEvent.keyboard('123');
+
+    setMask(null);
+    expect(api?.isComplete()).toBe(true);
+    // Upstream remove() writes the masked text back, placeholders included, and
+    // with no instance left unmaskedValue() falls through to element.value.
+    expect(api?.unmaskedValue()).toBe(input.value);
+    expect(input.value).toBe('123.___.___-__');
+
+    active?.root.unmount();
+    expect(api?.isComplete()).toBe(false);
+    expect(api?.unmaskedValue()).toBe('');
+  });
+
+  it('is true on an optional-tail mask as soon as the required part is in', async () => {
+    const input = renderHooked('br-bank-agency');
+    await focus(input);
+    await userEvent.keyboard('1');
+    expect(api?.isComplete()).toBe(true);
+  });
+
+  it('works the same through withMask', async () => {
+    const ref = withMask('cpf');
+    const input = mount(createElement('input', { ref }));
+    await focus(input);
+    await userEvent.keyboard(CPF);
+    expect(ref.isComplete()).toBe(true);
+  });
+});
+
+describe('getUnmaskedValue on event.target', () => {
+  it('hands onChange the digits while the field shows the mask', async () => {
+    const seen: string[] = [];
+    function Field() {
+      const ref = useMaskInput({ mask: 'cpf' });
+      return createElement('input', {
+        ref,
+        onChange: (e: { target: HTMLInputElement }) => seen.push(getUnmaskedValue(e.target)),
+      });
+    }
+    const input = mount(createElement(Field));
+    await focus(input);
+    await userEvent.keyboard('123');
+    expect(seen.at(-1)).toBe('123');
+    expect(input.value).toBe('123.___.___-__');
+  });
+
+  it('resolves a wrapper element down to the masked input inside it', async () => {
+    const input = renderHooked();
+    await focus(input);
+    await userEvent.keyboard('123');
+    expect(getUnmaskedValue(input.parentElement)).toBe('123');
+  });
+});
+
+describe('the accessors do not leak into spread props', () => {
+  it('keeps unmaskedValue and isComplete non-enumerable on the RHF result', () => {
+    let keys: string[] = [];
+    function Form() {
+      const { register } = useForm<{ cpf: string }>();
+      const registerWithMask = useHookFormMask(register);
+      const field = registerWithMask('cpf', 'cpf');
+      keys = Object.keys(field);
+      expect(field.isComplete()).toBe(false);
+      return createElement('input', field);
+    }
+    mount(createElement(Form));
+    expect(keys).not.toContain('isComplete');
+    expect(keys).not.toContain('unmaskedValue');
+  });
+});

--- a/packages/use-mask-input/src/api/controlledValue.browser.spec.ts
+++ b/packages/use-mask-input/src/api/controlledValue.browser.spec.ts
@@ -1,0 +1,205 @@
+/* eslint-disable import-x/no-extraneous-dependencies */
+import { userEvent } from '@vitest/browser/context';
+import { createElement, useEffect, useState } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { useController, useForm } from 'react-hook-form';
+import {
+  afterEach, describe, expect, it, vi,
+} from 'vitest';
+
+import useHookFormMask from './useHookFormMask';
+import useMaskInput from './useMaskInput';
+
+import type { ReactElement } from 'react';
+import type { Root } from 'react-dom/client';
+import type { UseFormReturn } from 'react-hook-form';
+import type { Options } from '../types';
+
+/**
+ * Programmatic value changes, in a real browser.
+ *
+ * Five issues (#62, #77, #128, #165, #193) reported the same family of symptom:
+ * a value that arrives from React state, RHF `reset()`/`setValue()`, or a
+ * `<Controller>` rather than from the keyboard, and a mask that either did not
+ * apply to it or lost the caret/selection afterwards. Each was fixed on its own.
+ * This spec pins the whole family so a change to the ref lifecycle cannot
+ * quietly reopen one of them.
+ *
+ * One thing here is a contract, not a bug: without `autoUnmask`, RHF's store
+ * keeps whatever `setValue` was given, raw or masked. The mask only owns the
+ * display. Apps that want the store raw set `autoUnmask: true`.
+ */
+
+let active: { root: Root; host: HTMLDivElement } | null = null;
+
+function mount(element: ReactElement): HTMLInputElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  flushSync(() => { root.render(element); });
+  active = { root, host };
+  const input = host.querySelector('input');
+  if (!input) throw new Error('no input rendered');
+  return input;
+}
+
+afterEach(() => {
+  active?.root.unmount();
+  active?.host.remove();
+  active = null;
+});
+
+function displayed(el: HTMLInputElement): string {
+  const native = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+  return native?.get?.call(el) as string;
+}
+
+const nextFrame = () => new Promise((resolve) => { requestAnimationFrame(() => resolve(null)); });
+async function focus(el: HTMLInputElement) { await userEvent.click(el); await nextFrame(); }
+
+const CPF = '12345678901';
+const MASKED = '123.456.789-01';
+
+let setExternal: (v: string) => void = () => {};
+let lastState = '';
+
+function renderControlled(options?: Options, initial = '') {
+  function Field() {
+    const [value, setValue] = useState(initial);
+    lastState = value;
+    setExternal = (v) => flushSync(() => setValue(v));
+    const ref = useMaskInput({ mask: 'cpf', options });
+    return createElement('input', { ref, value, onChange: (e: { target: HTMLInputElement }) => setValue(e.target.value) });
+  }
+  return mount(createElement(Field));
+}
+
+describe('controlled input via useState', () => {
+  it('typing keeps display masked and caret at the end', async () => {
+    const input = renderControlled();
+    await focus(input);
+    await userEvent.keyboard(CPF);
+    expect(displayed(input)).toBe(MASKED);
+    expect(lastState).toBe(MASKED);
+    expect(input.selectionStart).toBe(MASKED.length);
+  });
+
+  it('external setState with raw digits shows masked', async () => {
+    const input = renderControlled();
+    setExternal(CPF);
+    await nextFrame();
+    expect(displayed(input)).toBe(MASKED);
+  });
+
+  it('external setState then typing continues from the synced buffer', async () => {
+    const input = renderControlled();
+    setExternal('123456');
+    await nextFrame();
+    expect(displayed(input)).toBe('123.456.___-__');
+    await focus(input);
+    await userEvent.keyboard('78901');
+    expect(displayed(input)).toBe(MASKED);
+  });
+
+  it('external clear empties the field', async () => {
+    const input = renderControlled();
+    await focus(input);
+    await userEvent.keyboard(CPF);
+    setExternal('');
+    await nextFrame();
+    expect(displayed(input)).toBe('');
+  });
+
+  it('autoUnmask: state holds digits, external digits display masked', async () => {
+    const input = renderControlled({ autoUnmask: true });
+    await focus(input);
+    await userEvent.keyboard('12345');
+    expect(lastState).toBe('12345');
+    setExternal(CPF);
+    await nextFrame();
+    expect(displayed(input)).toBe(MASKED);
+    expect(input.value).toBe(CPF);
+  });
+
+  it('initial state value renders masked on mount', () => {
+    const input = renderControlled(undefined, CPF);
+    expect(displayed(input)).toBe(MASKED);
+  });
+});
+
+interface Values { cpf: string }
+let form: UseFormReturn<Values>;
+
+describe('react-hook-form programmatic value changes', () => {
+  function renderRHF(defaults?: Partial<Values>, options?: Options) {
+    function Form() {
+      const f = useForm<Values>({ defaultValues: { cpf: '', ...defaults } });
+      const registerWithMask = useHookFormMask(f.register);
+      useEffect(() => { form = f; }, [f]);
+      return createElement('input', registerWithMask('cpf', 'cpf', options));
+    }
+    return mount(createElement(Form));
+  }
+
+  it('defaultValues render masked', () => {
+    const input = renderRHF({ cpf: CPF });
+    expect(displayed(input)).toBe(MASKED);
+  });
+
+  it('setValue shows masked and the store keeps what it was given', async () => {
+    const input = renderRHF();
+    flushSync(() => form.setValue('cpf', CPF));
+    await nextFrame();
+    expect(displayed(input)).toBe(MASKED);
+    expect(form.getValues('cpf')).toBe(CPF);
+  });
+
+  it('setValue with autoUnmask keeps the store raw', async () => {
+    const input = renderRHF(undefined, { autoUnmask: true });
+    flushSync(() => form.setValue('cpf', CPF));
+    await nextFrame();
+    expect(displayed(input)).toBe(MASKED);
+    expect(form.getValues('cpf')).toBe(CPF);
+  });
+
+  it('reset() shows masked', async () => {
+    const input = renderRHF();
+    flushSync(() => form.reset({ cpf: CPF }));
+    await nextFrame();
+    expect(displayed(input)).toBe(MASKED);
+  });
+
+  it('reset() to empty clears the display after typing', async () => {
+    const input = renderRHF();
+    await focus(input);
+    await userEvent.keyboard(CPF);
+    flushSync(() => form.reset({ cpf: '' }));
+    await nextFrame();
+    expect(displayed(input)).toBe('');
+    expect(form.getValues('cpf')).toBe('');
+  });
+});
+
+describe('useController + useMaskInput with a predefined value (#193 follow-up)', () => {
+  it('select-all + delete fires onChange on the first attempt', async () => {
+    const onChange = vi.fn();
+    function Form() {
+      const f = useForm<Values>({ defaultValues: { cpf: CPF } });
+      const { field } = useController({ name: 'cpf', control: f.control });
+      const ref = useMaskInput({ mask: 'cpf' });
+      return createElement('input', {
+        ...field,
+        ref,
+        onChange: (e: { target: HTMLInputElement }) => { onChange(e.target.value); field.onChange(e); },
+      });
+    }
+    const input = mount(createElement(Form));
+    expect(displayed(input)).toBe(MASKED);
+    await focus(input);
+    input.select();
+    await userEvent.keyboard('{Delete}');
+    expect(onChange).toHaveBeenCalled();
+    expect(input.inputmask?.unmaskedvalue?.()).toBe('');
+  });
+});

--- a/packages/use-mask-input/src/api/useHookFormMask.ts
+++ b/packages/use-mask-input/src/api/useHookFormMask.ts
@@ -2,7 +2,7 @@ import { useLayoutEffect, useMemo, useRef } from 'react';
 
 import { applyMaskToElement } from '../core';
 import {
-  flow, getUnmaskedValue, makeMaskCacheKey, removeMask, setPrevRef, setUnmaskedValue,
+  flow, makeMaskCacheKey, removeMask, setPrevRef, setValueApi,
 } from '../utils';
 
 import type { RefCallback } from 'react';
@@ -111,7 +111,7 @@ export default function useHookFormMask<
         ...registerReturn,
         ref: entry.stableRef,
       } as UseHookFormMaskReturn<T>;
-      setUnmaskedValue(result, () => getUnmaskedValue(entry?.element ?? null));
+      setValueApi(result, () => entry?.element ?? null);
 
       setPrevRef(result, ref);
 

--- a/packages/use-mask-input/src/api/useMaskInput.ts
+++ b/packages/use-mask-input/src/api/useMaskInput.ts
@@ -6,7 +6,7 @@ import { applyMaskToElement, resolveInputRef } from '../core';
 import withMask from './withMask';
 import isServer from '../utils/isServer';
 import {
-  getUnmaskedValue, makeMaskCacheKey, removeMask, sameOptions, setUnmaskedValue,
+  makeMaskCacheKey, removeMask, sameOptions, setValueApi,
 } from '../utils';
 
 import type {
@@ -34,7 +34,6 @@ export default function useMaskInput(props: UseMaskInputOptions): UseMaskInputRe
   const ref = useRef<HTMLInputElement | null>(null);
   const maskRef = useRef(mask);
   const optionsRef = useRef(options);
-  const unmaskedValue = useCallback(() => getUnmaskedValue(ref.current), []);
 
   const refCallback = useCallback((input: Input | null): void => {
     if (!input) {
@@ -95,8 +94,8 @@ export default function useMaskInput(props: UseMaskInputOptions): UseMaskInputRe
       // server doesn't have dom, so just do nothing
     }) as unknown as UseMaskInputReturn;
 
-    return setUnmaskedValue(noop, () => '');
+    return setValueApi(noop, () => null);
   }
 
-  return setUnmaskedValue(refCallback, unmaskedValue);
+  return setValueApi(refCallback, () => ref.current);
 }

--- a/packages/use-mask-input/src/api/withHookFormMask.spec.ts
+++ b/packages/use-mask-input/src/api/withHookFormMask.spec.ts
@@ -27,6 +27,7 @@ const createRegister = (
   onBlur: vi.fn(),
   name: 'phone',
   unmaskedValue: vi.fn(() => ''),
+  isComplete: vi.fn(() => false),
   ...overrides,
 });
 

--- a/packages/use-mask-input/src/api/withHookFormMask.ts
+++ b/packages/use-mask-input/src/api/withHookFormMask.ts
@@ -1,6 +1,6 @@
 import { applyMaskToElement } from '../core';
 import {
-  getUnmaskedValue, makeMaskCacheKey, removeMask, setPrevRef, setUnmaskedValue,
+  makeMaskCacheKey, removeMask, setPrevRef, setValueApi,
 } from '../utils';
 
 import type { RefCallback } from 'react';
@@ -42,7 +42,7 @@ export default function withHookFormMask(
       ...register,
       ref: null as unknown as RefCallback<HTMLElement | null>,
     } as UseHookFormMaskReturn<FieldValues>;
-    setUnmaskedValue(result, () => '');
+    setValueApi(result, () => null);
     setPrevRef(result, ref);
     return result;
   }
@@ -69,7 +69,7 @@ export default function withHookFormMask(
     ...register,
     ref: maskedRef,
   } as UseHookFormMaskReturn<FieldValues>;
-  setUnmaskedValue(result, () => getUnmaskedValue(maskedRef?.currentElement ?? null));
+  setValueApi(result, () => maskedRef?.currentElement ?? null);
 
   setPrevRef(result, ref);
 

--- a/packages/use-mask-input/src/api/withMask.ts
+++ b/packages/use-mask-input/src/api/withMask.ts
@@ -3,7 +3,7 @@ import inputmask from '../core/inputmask';
 
 import { getMaskOptions } from '../core/maskConfig';
 import { stripMaxLength } from '../core/maskEngine';
-import { getUnmaskedValue, makeMaskCacheKey, setUnmaskedValue } from '../utils';
+import { makeMaskCacheKey, setValueApi } from '../utils';
 import isServer from '../utils/isServer';
 import interopDefaultSync from '../utils/moduleInterop';
 
@@ -44,5 +44,5 @@ export default function withMask(mask: Mask, options?: Options): UseMaskInputRet
     callbackCache.set(cacheKey, callback);
   }
 
-  return setUnmaskedValue(callback, () => getUnmaskedValue(currentInput));
+  return setValueApi(callback, () => currentInput);
 }

--- a/packages/use-mask-input/src/api/withTanStackFormMask.ts
+++ b/packages/use-mask-input/src/api/withTanStackFormMask.ts
@@ -1,6 +1,6 @@
 import { applyMaskToElement } from '../core';
 import {
-  getUnmaskedValue, makeMaskCacheKey, removeMask, setPrevRef, setUnmaskedValue,
+  makeMaskCacheKey, removeMask, setPrevRef, setValueApi,
 } from '../utils';
 
 import type { RefCallback } from 'react';
@@ -39,7 +39,7 @@ export default function withTanStackFormMask<T extends TanStackFormInputProps>(
         if (input) applyMaskToElement(input, mask, options);
       }) as RefCallback<HTMLElement | null>,
     } as unknown as UseTanStackFormMaskReturn<T>;
-    setUnmaskedValue(result, () => getUnmaskedValue(currentElement));
+    setValueApi(result, () => currentElement);
 
     setPrevRef(result, ref);
     return result;
@@ -68,7 +68,7 @@ export default function withTanStackFormMask<T extends TanStackFormInputProps>(
     ...inputProps,
     ref: maskedRef,
   } as unknown as UseTanStackFormMaskReturn<T>;
-  setUnmaskedValue(result, () => getUnmaskedValue(maskedRef?.currentElement ?? null));
+  setValueApi(result, () => maskedRef?.currentElement ?? null);
 
   setPrevRef(result, ref);
   return result;

--- a/packages/use-mask-input/src/core/isValidWithMask.spec.ts
+++ b/packages/use-mask-input/src/core/isValidWithMask.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { isValidWithMask } from './maskEngine';
+
+import type { Mask } from '../types';
+
+/**
+ * Real engine, no mocks: the answer for each built-in alias, fed the value the
+ * way a schema validator sees it. `maskEngine.spec.ts` covers the call shape;
+ * this file exists because `Inputmask.isValid` alone said "false" for a
+ * complete phone-br, credit-card, brl-currency and mac, and this table is the
+ * proof it no longer does.
+ */
+const VALID: [Mask, string][] = [
+  ['cpf', '12345678901'],
+  ['cpf', '123.456.789-01'],
+  ['cnpj', '12345678000195'],
+  ['cep', '12345678'],
+  ['phone-br', '1199999999'],
+  ['phone-br', '11999999999'],
+  ['phone-br', '(11) 99999-9999'],
+  ['credit-card', '4111111111111111'],
+  ['credit-card', '378282246310005'],
+  ['plate-br', 'ABC1234'],
+  ['plate-br', 'abc1d23'],
+  ['br-bank-account', '1234567-9'],
+  ['br-bank-agency', '1234'],
+  ['br-bank-agency', '1234-5'],
+  ['brl-currency', '1000'],
+  ['brl-currency', '1000,00'],
+  ['currency', '10'],
+  ['percentage', '50'],
+  ['numeric', '1234.5'],
+  ['integer', '42'],
+  ['date-br', '12122024'],
+  ['date-br', '12/12/2024'],
+  ['time', '23:59'],
+  ['email', 'a@b.co'],
+  ['url', 'https://x.io'],
+  ['ip', '1.1.1.1'],
+  ['mac', 'aa:bb:cc:dd:ee:ff'],
+  ['ssn', '123456789'],
+  [['99-99', '999-999'], '1234'],
+  ['9{1,3}', '12'],
+];
+
+const INVALID: [Mask, string][] = [
+  ['cpf', ''],
+  ['cpf', '123'],
+  ['cpf', 'abc'],
+  ['phone-br', '119999'],
+  ['credit-card', '4111'],
+  ['plate-br', 'AB'],
+  ['br-bank-account', '1234567'],
+  ['br-bank-agency', ''],
+  ['numeric', 'abc'],
+  ['date-br', '12/12/20'],
+  ['time', '2'],
+  ['email', 'a@b'],
+  ['email', 'not an email'],
+  ['ip', '1.1'],
+  ['9{1,3}', ''],
+];
+
+describe('isValidWithMask against the real engine', () => {
+  it.each(VALID)('%s accepts %j', (mask, value) => {
+    expect(isValidWithMask(value, mask)).toBe(true);
+  });
+
+  it.each(INVALID)('%s rejects %j', (mask, value) => {
+    expect(isValidWithMask(value, mask)).toBe(false);
+  });
+
+  it('treats a null mask as no constraint', () => {
+    expect(isValidWithMask('anything', null)).toBe(true);
+  });
+
+  // Empty is not one answer across aliases: literal masks have required
+  // positions, open-ended numeric ones do not. Schemas own "required".
+  it('answers empty per mask', () => {
+    expect(isValidWithMask('', 'numeric')).toBe(true);
+    expect(isValidWithMask('', 'brl-currency')).toBe(true);
+    expect(isValidWithMask('', 'cpf')).toBe(false);
+  });
+});

--- a/packages/use-mask-input/src/core/maskEngine.spec.ts
+++ b/packages/use-mask-input/src/core/maskEngine.spec.ts
@@ -153,18 +153,29 @@ describe('maskEngine', () => {
   });
 
   describe('isValidWithMask', () => {
-    it('delegates to Inputmask.isValid with the resolved alias options', () => {
+    it('formats first, then hands the masked string to Inputmask.isValid', () => {
       const isValidFn = vi.fn().mockReturnValue(true);
+      vi.mocked(inputmask).format = vi.fn().mockReturnValue('123.456.789-00');
       vi.mocked(inputmask).isValid = isValidFn;
 
-      expect(isValidWithMask('123.456.789-00', 'cpf')).toBe(true);
+      expect(isValidWithMask('12345678900', 'cpf')).toBe(true);
       expect(isValidFn).toHaveBeenCalledWith(
         '123.456.789-00',
         expect.objectContaining({ mask: '999.999.999-99' }),
       );
     });
 
+    it('rejects a non-empty value the engine formats to nothing', () => {
+      vi.mocked(inputmask).format = vi.fn().mockReturnValue('');
+      const isValidFn = vi.fn().mockReturnValue(true);
+      vi.mocked(inputmask).isValid = isValidFn;
+
+      expect(isValidWithMask('abc', 'numeric')).toBe(false);
+      expect(isValidFn).not.toHaveBeenCalled();
+    });
+
     it('coerces a non-boolean engine result to false', () => {
+      vi.mocked(inputmask).format = vi.fn().mockReturnValue('12');
       vi.mocked(inputmask).isValid = vi.fn().mockReturnValue(undefined);
       expect(isValidWithMask('12', 'cpf')).toBe(false);
     });

--- a/packages/use-mask-input/src/core/maskEngine.spec.ts
+++ b/packages/use-mask-input/src/core/maskEngine.spec.ts
@@ -4,7 +4,7 @@ import {
 } from 'vitest';
 
 import {
-  applyMaskToElement, createMaskInstance, formatWithMask, unformatWithMask,
+  applyMaskToElement, createMaskInstance, formatWithMask, isValidWithMask, unformatWithMask,
 } from './maskEngine';
 
 type MaskInstance = ReturnType<typeof createMaskInstance>;
@@ -18,7 +18,7 @@ vi.mock('./inputmask', () => {
     mask: vi.fn(),
     options,
   }));
-  return { default: Object.assign(mockInputmask, { format: vi.fn(), unmask: vi.fn() }) };
+  return { default: Object.assign(mockInputmask, { format: vi.fn(), unmask: vi.fn(), isValid: vi.fn() }) };
 });
 
 describe('maskEngine', () => {
@@ -149,6 +149,24 @@ describe('maskEngine', () => {
         '999999',
         expect.objectContaining({ mask: '999-999', placeholder: '_' }),
       );
+    });
+  });
+
+  describe('isValidWithMask', () => {
+    it('delegates to Inputmask.isValid with the resolved alias options', () => {
+      const isValidFn = vi.fn().mockReturnValue(true);
+      vi.mocked(inputmask).isValid = isValidFn;
+
+      expect(isValidWithMask('123.456.789-00', 'cpf')).toBe(true);
+      expect(isValidFn).toHaveBeenCalledWith(
+        '123.456.789-00',
+        expect.objectContaining({ mask: '999.999.999-99' }),
+      );
+    });
+
+    it('coerces a non-boolean engine result to false', () => {
+      vi.mocked(inputmask).isValid = vi.fn().mockReturnValue(undefined);
+      expect(isValidWithMask('12', 'cpf')).toBe(false);
     });
   });
 

--- a/packages/use-mask-input/src/core/maskEngine.ts
+++ b/packages/use-mask-input/src/core/maskEngine.ts
@@ -49,6 +49,21 @@ export function unformatWithMask(value: string, mask: Mask, options?: Options): 
 }
 
 /**
+ * Whether a value satisfies the mask, without needing a mounted element.
+ * Useful inside schema validators (zod, yup, vee-validate rules) that only see
+ * the raw form value.
+ *
+ * @param value - The value to check, masked or unmasked
+ * @param mask - The mask pattern
+ * @param options - Optional configuration options
+ * @returns True when the value is a complete, valid entry for the mask
+ */
+export function isValidWithMask(value: string, mask: Mask, options?: Options): boolean {
+  const inputmaskInstance = moduleInterop(inputmask);
+  return inputmaskInstance.isValid(value, getMaskOptions(mask, options)) === true;
+}
+
+/**
  * Drops the native `maxlength` when the mask renders characters the user never types.
  *
  * A mask like `999.999.999-99` keeps its literals and placeholder in the value, so

--- a/packages/use-mask-input/src/core/maskEngine.ts
+++ b/packages/use-mask-input/src/core/maskEngine.ts
@@ -49,9 +49,18 @@ export function unformatWithMask(value: string, mask: Mask, options?: Options): 
 }
 
 /**
- * Whether a value satisfies the mask, without needing a mounted element.
- * Useful inside schema validators (zod, yup, vee-validate rules) that only see
- * the raw form value.
+ * Whether a value is a complete, valid entry for the mask, without needing a
+ * mounted element. Useful inside schema validators (zod, yup, vee-validate
+ * rules) that only see the raw form value.
+ *
+ * Accepts the value masked or unmasked. `Inputmask.isValid` on its own only
+ * accepts the exact masked string, so the value is run through `format` first;
+ * the answer then matches what `isComplete()` reports on a field holding it.
+ *
+ * ponytail: the engine drops input it cannot place, the same way the field
+ * does, so `'123456789012'` formats to a full cpf and passes. Length limits
+ * belong in the schema. A non-empty value that formats to nothing is rejected
+ * here, or `numeric` would call `'abc'` valid.
  *
  * @param value - The value to check, masked or unmasked
  * @param mask - The mask pattern
@@ -60,7 +69,11 @@ export function unformatWithMask(value: string, mask: Mask, options?: Options): 
  */
 export function isValidWithMask(value: string, mask: Mask, options?: Options): boolean {
   const inputmaskInstance = moduleInterop(inputmask);
-  return inputmaskInstance.isValid(value, getMaskOptions(mask, options)) === true;
+  const maskOptions = getMaskOptions(mask, options);
+  const formatted = inputmaskInstance.format(value, maskOptions);
+  if (value !== '' && formatted === '') return false;
+
+  return inputmaskInstance.isValid(formatted, maskOptions) === true;
 }
 
 /**

--- a/packages/use-mask-input/src/index.tsx
+++ b/packages/use-mask-input/src/index.tsx
@@ -7,7 +7,8 @@ export {
   withTanStackFormMask,
 } from './api';
 
-export { formatWithMask, unformatWithMask } from './core';
+export { formatWithMask, isValidWithMask, unformatWithMask } from './core';
+export { getUnmaskedValue, isMaskComplete } from './utils';
 
 export type {
   Input,

--- a/packages/use-mask-input/src/types/mask.ts
+++ b/packages/use-mask-input/src/types/mask.ts
@@ -40,4 +40,6 @@ export type Input = HTMLInputElement | HTMLTextAreaElement | HTMLElement;
 
 export interface UnmaskedValueApi {
   unmaskedValue: () => string;
+  /** Whether every required position of the mask is filled. */
+  isComplete: () => boolean;
 }

--- a/packages/use-mask-input/src/utils/index.ts
+++ b/packages/use-mask-input/src/utils/index.ts
@@ -3,9 +3,10 @@ export { default as isServer } from './isServer';
 export { default as moduleInterop } from './moduleInterop';
 export {
   getUnmaskedValue,
+  isMaskComplete,
   makeMaskCacheKey,
   removeMask,
   sameOptions,
   setPrevRef,
-  setUnmaskedValue,
+  setValueApi,
 } from './maskHelpers';

--- a/packages/use-mask-input/src/utils/maskHelpers.spec.ts
+++ b/packages/use-mask-input/src/utils/maskHelpers.spec.ts
@@ -71,3 +71,25 @@ describe('maskHelpers', () => {
     });
   });
 });
+
+describe('isMaskComplete', () => {
+  it('is false without an element and true for an element with no mask', async () => {
+    const { isMaskComplete } = await import('./maskHelpers');
+    expect(isMaskComplete(null)).toBe(false);
+    expect(isMaskComplete(document.createElement('input'))).toBe(true);
+  });
+
+  it('tracks the real inputmask instance as the value fills the mask', async () => {
+    const { isMaskComplete } = await import('./maskHelpers');
+    const { applyMaskToElement } = await import('../core');
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    applyMaskToElement(input, 'cpf');
+
+    input.inputmask?.setValue?.('123');
+    expect(isMaskComplete(input)).toBe(false);
+
+    input.inputmask?.setValue?.('12345678901');
+    expect(isMaskComplete(input)).toBe(true);
+  });
+});

--- a/packages/use-mask-input/src/utils/maskHelpers.ts
+++ b/packages/use-mask-input/src/utils/maskHelpers.ts
@@ -8,7 +8,11 @@ import type {
 // this module type-checks when consumers compile the package source directly,
 // e.g. the example apps that alias `use-mask-input` to `src` and build with `tsc`.
 type MaskedElement = (HTMLInputElement | HTMLTextAreaElement) & {
-  inputmask?: { unmaskedvalue?: () => string; remove?: () => void };
+  inputmask?: {
+    unmaskedvalue?: () => string;
+    isComplete?: () => boolean | undefined;
+    remove?: () => void;
+  };
 };
 
 /**
@@ -82,6 +86,25 @@ export function getUnmaskedValue(input: Input | null): string {
 }
 
 /**
+ * Whether every required position of the mask on `input` is filled.
+ *
+ * No element yet (unmounted, SSR) reads as incomplete. An element with no mask
+ * attached, or a mask Inputmask cannot judge (`repeat: '*'` yields `undefined`),
+ * reads as complete: there is no pattern left to finish.
+ */
+export function isMaskComplete(input: Input | null): boolean {
+  const element = resolveUnmaskedInput(input);
+  if (!element) return false;
+
+  const { inputmask } = element as MaskedElement;
+  if (inputmask && typeof inputmask.isComplete === 'function') {
+    return inputmask.isComplete() !== false;
+  }
+
+  return true;
+}
+
+/**
  * Detaches Inputmask from an element, restoring the native `value` accessor it
  * overrode and dropping the listeners it installed.
  *
@@ -100,16 +123,28 @@ export function removeMask(input: Input | null): void {
   element?.inputmask?.remove?.();
 }
 
-export function setUnmaskedValue<T extends object>(
+/**
+ * Hangs `unmaskedValue()` and `isComplete()` on a hook result as non-enumerable
+ * properties, so spreading the result into JSX props does not leak them.
+ *
+ * @param result - The ref callback or props object being returned to the caller
+ * @param getElement - Resolves the currently masked element, or null
+ */
+export function setValueApi<T extends object>(
   result: T,
-  getter: () => string,
+  getElement: () => Input | null,
 ): T & UnmaskedValueApi {
-  Object.defineProperty(result, 'unmaskedValue', {
-    value: getter,
-    enumerable: false,
-    writable: true,
-    configurable: true,
-  });
+  const define = (key: keyof UnmaskedValueApi, value: () => unknown) => {
+    Object.defineProperty(result, key, {
+      value,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+  };
+
+  define('unmaskedValue', () => getUnmaskedValue(getElement()));
+  define('isComplete', () => isMaskComplete(getElement()));
 
   return result as T & UnmaskedValueApi;
 }

--- a/packages/use-mask-input/src/vue/index.ts
+++ b/packages/use-mask-input/src/vue/index.ts
@@ -1,7 +1,8 @@
 export { default as vMaskInput } from './directive';
 export { default as useMaskInput } from './useMaskInput';
 
-export { formatWithMask, unformatWithMask } from '../core';
+export { formatWithMask, isValidWithMask, unformatWithMask } from '../core';
+export { getUnmaskedValue, isMaskComplete } from '../utils';
 
 export type {
   Mask,

--- a/packages/use-mask-input/src/vue/types.ts
+++ b/packages/use-mask-input/src/vue/types.ts
@@ -32,4 +32,6 @@ export interface UseMaskInputReturn {
    * value the template should track, bind `v-model` with `autoUnmask: true`.
    */
   unmaskedValue: () => string;
+  /** Whether every required position of the mask is filled. Not reactive, same as `unmaskedValue`. */
+  isComplete: () => boolean;
 }

--- a/packages/use-mask-input/src/vue/useMaskInput-server.spec.ts
+++ b/packages/use-mask-input/src/vue/useMaskInput-server.spec.ts
@@ -12,12 +12,13 @@ describe('useMaskInput server-side', () => {
     vi.resetModules();
   });
 
-  it('returns a no-op ref and an empty unmasked value', async () => {
+  it('returns a no-op ref, an empty unmasked value and incomplete', async () => {
     const { default: useMaskInput } = await import('./useMaskInput');
-    const { maskRef, unmaskedValue } = useMaskInput('cpf');
+    const { maskRef, unmaskedValue, isComplete } = useMaskInput('cpf');
 
     expect(typeof maskRef).toBe('function');
     expect(unmaskedValue()).toBe('');
+    expect(isComplete()).toBe(false);
   });
 
   it('does not mask when the ref is called on the server', async () => {

--- a/packages/use-mask-input/src/vue/useMaskInput.spec.ts
+++ b/packages/use-mask-input/src/vue/useMaskInput.spec.ts
@@ -26,21 +26,25 @@ describe('useMaskInput', () => {
     expect(input.inputmask?.opts?.prefix).toBe('R$ ');
   });
 
-  it('returns the unmasked value', () => {
-    const { maskRef, unmaskedValue } = useMaskInput('cpf');
+  it('returns the unmasked value and completeness', () => {
+    const { maskRef, unmaskedValue, isComplete } = useMaskInput('cpf');
     const input = document.createElement('input');
     document.body.appendChild(input);
 
     maskRef(input);
-    input.inputmask?.setValue?.('12345678901');
+    input.inputmask?.setValue?.('123');
+    expect(isComplete()).toBe(false);
 
+    input.inputmask?.setValue?.('12345678901');
     expect(input.value).toBe('123.456.789-01');
     expect(unmaskedValue()).toBe('12345678901');
+    expect(isComplete()).toBe(true);
   });
 
-  it('returns an empty string before the ref is attached', () => {
-    const { unmaskedValue } = useMaskInput('cpf');
+  it('returns an empty string and incomplete before the ref is attached', () => {
+    const { unmaskedValue, isComplete } = useMaskInput('cpf');
     expect(unmaskedValue()).toBe('');
+    expect(isComplete()).toBe(false);
   });
 
   it('clears its element when the ref detaches on unmount', () => {

--- a/packages/use-mask-input/src/vue/useMaskInput.ts
+++ b/packages/use-mask-input/src/vue/useMaskInput.ts
@@ -1,6 +1,6 @@
 import applyMask from './applyMask';
 import resolveVueElement from './resolveVueElement';
-import { getUnmaskedValue } from '../utils';
+import { getUnmaskedValue, isMaskComplete } from '../utils';
 import isServer from '../utils/isServer';
 
 import type {
@@ -39,6 +39,7 @@ export default function useMaskInput(mask: Mask, options?: Options): UseMaskInpu
         // server doesn't have dom, so just do nothing
       },
       unmaskedValue: () => '',
+      isComplete: () => false,
     };
   }
 
@@ -52,5 +53,6 @@ export default function useMaskInput(mask: Mask, options?: Options): UseMaskInpu
   return {
     maskRef,
     unmaskedValue: () => getUnmaskedValue(element),
+    isComplete: () => isMaskComplete(element),
   };
 }


### PR DESCRIPTION
## What

Every hook and `with*` helper now returns `isComplete()` next to `unmaskedValue()`, for React and Vue. Three standalone helpers join the entry points:

| Helper | Use |
|---|---|
| `isValidWithMask(value, mask)` | schema validators (zod, yup, vee-validate rules) that only see the raw form value |
| `getUnmaskedValue(el)` | reading the raw value off `event.target` inside `onChange` (#60) |
| `isMaskComplete(el)` | standalone form of `isComplete()` |

## Why

Form validation needs to know whether a CPF is fully typed. Inputmask already has `instance.isComplete()` and `Inputmask.isValid()`; the library just never exposed them, so people wrote regexes on the side. `getUnmaskedValue` existed in `utils` but never left the package.

## Also in here

- `setUnmaskedValue` became `setValueApi(result, getElement)` so both accessors are defined in one place.
- `useHookFormMaskAntd` now actually sets `unmaskedValue()` and `isComplete()`. Its return type always promised them; the runtime never delivered.
- New `controlledValue.browser.spec.ts` pins programmatic value changes (`useState`, RHF `setValue`/`reset`, `useController` with a predefined value) in real Chromium, so the #62/#77/#128/#165/#193 family cannot reopen without a red test. All 12 scenarios pass on current `main`; this is coverage, not a fix.

## Checks

unit 285/285, browser 61/61, lint, type-check, build. Changeset: minor.


## Stress pass (second commit)

`Inputmask.isValid` only accepts the exact masked string, so the first cut of `isValidWithMask` said false for raw digits and for every complete `phone-br`, `credit-card`, `brl-currency` and `mac`. It now formats first, and a non-empty value that formats to nothing is rejected (`numeric` + `'abc'`). `isValidWithMask.spec.ts` pins 45 valid/invalid rows against the real engine; `completeness.browser.spec.ts` drives `isComplete()` and `getUnmaskedValue()` from the keyboard.

Known engine limits, left alone: `31/02/2024` passes `date-br`, trailing overflow is dropped the way the field drops it, and empty is valid for open-ended aliases (`numeric`, `brl-currency`) but not for literal ones (`cpf`). Schemas own "required" and length.

Checks after the second commit: unit 333/333, browser 68/68.
