### PR TITLE
fix(docs): correct SEO metadata and URL canonicalization

### DIFF
--- a/.changeset/seo-homepage-field.md
+++ b/.changeset/seo-homepage-field.md
@@ -1,0 +1,5 @@
+---
+"use-mask-input": patch
+---
+
+Add the `homepage` field to `package.json` so the npm page links to the documentation site.

--- a/apps/docussaurus/docusaurus.config.ts
+++ b/apps/docussaurus/docusaurus.config.ts
@@ -26,6 +26,10 @@ const config: Config = {
   organizationName: 'eduardoborges', // Usually your GitHub org/user name.
   projectName: 'use-mask-input', // Usually your repo name.
 
+  // Cloudflare Pages 308-redirects /path -> /path/. Match it so sitemap,
+  // canonical and the served URL all agree.
+  trailingSlash: true,
+
   onBrokenLinks: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set

--- a/apps/docussaurus/src/pages/index.tsx
+++ b/apps/docussaurus/src/pages/index.tsx
@@ -403,7 +403,7 @@ function Stats() {
 export default function Home(): React.JSX.Element {
   return (
     <Layout
-      title="use-mask-input — Input masks for React and Vue"
+      title="Input masks for React and Vue 3"
       description="Input masks for React and Vue 3. Works with plain inputs, React Hook Form, TanStack Form, vee-validate, shadcn/ui and Ant Design."
     >
       <main className={styles.homepage}>

--- a/docs/antd.md
+++ b/docs/antd.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 3
+title: "Ant Design input masks"
+sidebar_label: "Ant Design"
+description: "Mask Ant Design Input and Form fields. Dedicated hooks unwrap Ant Design's InputRef for you, so masks work without touching the component internals."
 ---
 
 # Ant Design Integration
@@ -312,7 +315,7 @@ function AntdForm() {
 
 ## API Reference
 
-For full API documentation of all exports (including standard hooks, higher-order functions, and types), see the **[API Reference](./api-reference)** page.
+For full API documentation of all exports (including standard hooks, higher-order functions, and types), see the **[API Reference](/api-reference)** page.
 
 Below is a quick reference for the Ant Design-specific hooks.
 
@@ -402,7 +405,7 @@ function CreditCardInput() {
 
 ## Next Steps
 
-- Explore [mask types](./tutorial-basics/static-mask)
-- Check out [all available aliases](./tutorial-basics/alias-mask)
-- Learn about [optional masks](./tutorial-basics/optional-mask)
-- Discover [dynamic masks](./tutorial-basics/dynamic-mask)
+- Explore [mask types](/tutorial-basics/static-mask)
+- Check out [all available aliases](/tutorial-basics/alias-mask)
+- Learn about [optional masks](/tutorial-basics/optional-mask)
+- Discover [dynamic masks](/tutorial-basics/dynamic-mask)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 2
+title: "API reference"
+sidebar_label: "API Reference"
+description: "Every export of use-mask-input: useMaskInput, withMask, useHookFormMask, useTanStackFormMask, the Vue directive vMaskInput, options and built-in aliases."
 ---
 
 # API Reference
@@ -416,7 +419,7 @@ function PhoneInput() {
 }
 ```
 
-See the full [Ant Design Integration](./antd) guide for Form.Item, useWatch, and validation examples.
+See the full [Ant Design Integration](/antd) guide for Form.Item, useWatch, and validation examples.
 
 ---
 

--- a/docs/discoverability.md
+++ b/docs/discoverability.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 100
+description: "Machine-readable discovery files published by this site: robots.txt, llms.txt, llms-full.txt and /.well-known/ endpoints for crawlers and AI agents."
 ---
 
 # Agent discovery

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 1
+title: "use-mask-input — input masks for React and Vue 3"
+sidebar_label: "use-mask-input"
+description: "Add input masks to React and Vue 3 forms: CPF, phone, currency, date. One hook, no controlled state, works with React Hook Form and vee-validate."
 ---
 
 # use-mask-input
@@ -105,7 +108,7 @@ function MyForm() {
 }
 ```
 
-See the full [TanStack Form Integration](./tanstack-form) guide.
+See the full [TanStack Form Integration](/tanstack-form) guide.
 
 ## With Ant Design
 
@@ -119,7 +122,7 @@ function EmailInput() {
 }
 ```
 
-See the full [Ant Design Integration](./antd) guide.
+See the full [Ant Design Integration](/antd) guide.
 
 ## With shadcn/ui
 
@@ -135,7 +138,7 @@ function CepField() {
 }
 ```
 
-See the full [shadcn/ui Integration](./shadcn) guide.
+See the full [shadcn/ui Integration](/shadcn) guide.
 
 ## With Vue 3
 
@@ -155,7 +158,7 @@ const cpf = ref('');
 </template>
 ```
 
-`v-model` works without an adapter, and so does vee-validate. See the full [Vue 3](./vue) guide.
+`v-model` works without an adapter, and so does vee-validate. See the full [Vue 3](/vue) guide.
 
 ## APIs
 
@@ -163,36 +166,36 @@ const cpf = ref('');
 
 | API | When to use |
 |-----|-------------|
-| [`useMaskInput`](./api-reference#usemaskinput) | Default choice. Returns a ref callback. |
-| [`useHookFormMask`](./api-reference#usehookformmask) | Wraps React Hook Form's `register`. |
-| [`useTanStackFormMask`](./api-reference#usetanstackformmask) | Wraps TanStack Form input props with mask support. |
-| [`withMask`](./api-reference#withmask) | Non-hook ref callback. **Requires `React.memo`.** |
-| [`withHookFormMask`](./api-reference#withhookformmask) | Non-hook mask for registered fields. **Requires `React.memo`.** |
-| [`withTanStackFormMask`](./api-reference#withtanstackformmask) | Non-hook mask for TanStack input props. **Requires `React.memo`.** |
-| [`useMaskInputAntd`](./api-reference#usemaskinputantd) | `useMaskInput` for Ant Design. |
-| [`useHookFormMaskAntd`](./api-reference#usehookformmaskantd) | `useHookFormMask` for Ant Design. |
+| [`useMaskInput`](/api-reference#usemaskinput) | Default choice. Returns a ref callback. |
+| [`useHookFormMask`](/api-reference#usehookformmask) | Wraps React Hook Form's `register`. |
+| [`useTanStackFormMask`](/api-reference#usetanstackformmask) | Wraps TanStack Form input props with mask support. |
+| [`withMask`](/api-reference#withmask) | Non-hook ref callback. **Requires `React.memo`.** |
+| [`withHookFormMask`](/api-reference#withhookformmask) | Non-hook mask for registered fields. **Requires `React.memo`.** |
+| [`withTanStackFormMask`](/api-reference#withtanstackformmask) | Non-hook mask for TanStack input props. **Requires `React.memo`.** |
+| [`useMaskInputAntd`](/api-reference#usemaskinputantd) | `useMaskInput` for Ant Design. |
+| [`useHookFormMaskAntd`](/api-reference#usehookformmaskantd) | `useHookFormMask` for Ant Design. |
 
 ### Vue
 
 | API | When to use |
 |-----|-------------|
-| [`vMaskInput`](./api-reference#vmaskinput) | Default choice. A directive, usable as `v-mask-input`. |
-| [`useMaskInput` (Vue)](./api-reference#usemaskinput-vue) | Composable, for imperative reads and `unmaskedValue()`. |
+| [`vMaskInput`](/api-reference#vmaskinput) | Default choice. A directive, usable as `v-mask-input`. |
+| [`useMaskInput` (Vue)](/api-reference#usemaskinput-vue) | Composable, for imperative reads and `unmaskedValue()`. |
 
 ### Both
 
 | API | When to use |
 |-----|-------------|
-| [`formatWithMask`](./api-reference#formatwithmask) | Format a stored value without a mounted element. |
-| [`unformatWithMask`](./api-reference#unformatwithmask) | Strip a mask from a formatted value. |
+| [`formatWithMask`](/api-reference#formatwithmask) | Format a stored value without a mounted element. |
+| [`unformatWithMask`](/api-reference#unformatwithmask) | Strip a mask from a formatted value. |
 
-Full signatures and parameters in the [API Reference](./api-reference).
+Full signatures and parameters in the [API Reference](/api-reference).
 
 ## Mask Types
 
-- [Static Mask](./tutorial-basics/static-mask): fixed patterns like `999-999`
-- [Dynamic Mask](./tutorial-basics/dynamic-mask): variable-length patterns
-- [Optional Mask](./tutorial-basics/optional-mask): masks with optional parts
-- [Alias Mask](./tutorial-basics/alias-mask): built-in presets (`email`, `currency`, `datetime`, ...)
-- [Alternator Mask](./tutorial-basics/alternator-mask): multiple patterns
-- [Preprocessing Mask](./tutorial-basics/preprocessing-mask): dynamic masks with functions
+- [Static Mask](/tutorial-basics/static-mask): fixed patterns like `999-999`
+- [Dynamic Mask](/tutorial-basics/dynamic-mask): variable-length patterns
+- [Optional Mask](/tutorial-basics/optional-mask): masks with optional parts
+- [Alias Mask](/tutorial-basics/alias-mask): built-in presets (`email`, `currency`, `datetime`, ...)
+- [Alternator Mask](/tutorial-basics/alternator-mask): multiple patterns
+- [Preprocessing Mask](/tutorial-basics/preprocessing-mask): dynamic masks with functions

--- a/docs/shadcn.md
+++ b/docs/shadcn.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 5
+title: "shadcn/ui input masks"
+sidebar_label: "shadcn/ui"
+description: "Mask shadcn/ui Input fields with no adapter. The component forwards a native input ref, so the base hooks handle it directly."
 ---
 
 # shadcn/ui Integration

--- a/docs/tanstack-form.md
+++ b/docs/tanstack-form.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 4
+title: "TanStack Form input masks"
+sidebar_label: "TanStack Form"
+description: "Mask TanStack Form fields with useTanStackFormMask, or withTanStackFormMask when the field is wrapped in React.memo."
 ---
 
 # TanStack Form Integration

--- a/docs/tutorial-basics/alias-mask.md
+++ b/docs/tutorial-basics/alias-mask.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 4
+title: "Alias masks"
+sidebar_label: "Alias Mask"
+description: "Ready-made masks for dates, currency, email, CPF, CNPJ and more. Pass the alias name instead of writing the pattern by hand."
 ---
 
 # Alias Mask

--- a/docs/tutorial-basics/alternator-mask.md
+++ b/docs/tutorial-basics/alternator-mask.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 5
+title: "Alternator masks"
+sidebar_label: "Alternator Mask"
+description: "Accept several patterns in one field with the pipe character, so a single input matches any of the masks you list."
 ---
 
 # Alternator Mask

--- a/docs/tutorial-basics/dynamic-mask.md
+++ b/docs/tutorial-basics/dynamic-mask.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 3
+title: "Dynamic masks"
+sidebar_label: "Dynamic Mask"
+description: "Use curly braces to repeat parts of a mask, for inputs whose length varies such as emails and variable-length numbers."
 ---
 
 # Dynamic Mask

--- a/docs/tutorial-basics/optional-mask.md
+++ b/docs/tutorial-basics/optional-mask.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 2
+title: "Optional masks"
+sidebar_label: "Optional Mask"
+description: "Use square brackets to make parts of a mask optional, so one pattern accepts phone numbers with or without an area code."
 ---
 
 # Optional Mask

--- a/docs/tutorial-basics/preprocessing-mask.md
+++ b/docs/tutorial-basics/preprocessing-mask.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 6
+title: "Preprocessing masks"
+sidebar_label: "Preprocessing Mask"
+description: "Define the mask as a function to pick the pattern at runtime, for conditional logic or masks loaded dynamically."
 ---
 
 # Preprocessing Mask

--- a/docs/tutorial-basics/static-mask.md
+++ b/docs/tutorial-basics/static-mask.md
@@ -1,5 +1,8 @@
 ---
 sidebar_position: 1
+title: "Static masks"
+sidebar_label: "Static Mask"
+description: "Masks with a fixed pattern, the most common kind. Learn the mask characters and how to format phone numbers, dates and documents."
 ---
 
 # Static Mask

--- a/docs/vue.md
+++ b/docs/vue.md
@@ -1,10 +1,13 @@
 ---
 sidebar_position: 6
+title: "Vue 3 input masks"
+sidebar_label: "Vue 3"
+description: "Mask inputs in Vue 3 with the vMaskInput directive or the useMaskInput composable, including vee-validate forms. Same mask engine and aliases as the React API."
 ---
 
 # Vue 3
 
-**use-mask-input** ships a Vue 3 entry point alongside the React one. It reuses the same mask engine and the same [built-in aliases](./api-reference.md), so a `cpf` mask behaves identically in both frameworks.
+**use-mask-input** ships a Vue 3 entry point alongside the React one. It reuses the same mask engine and the same [built-in aliases](/api-reference.md), so a `cpf` mask behaves identically in both frameworks.
 
 ```ts
 import { vMaskInput, useMaskInput } from 'use-mask-input/vue';
@@ -171,7 +174,7 @@ Aliases carry defaults that your options override individually. This keeps the a
 <input v-mask-input="{ mask: 'brl-currency', options: { prefix: 'US$ ' } }" />
 ```
 
-Anything that is not a known alias is treated as a raw pattern, so `'(99) 99999-9999'` and `'AAA-9A99'` work directly. Full option list in the [API Reference](./api-reference#options).
+Anything that is not a known alias is treated as a raw pattern, so `'(99) 99999-9999'` and `'AAA-9A99'` work directly. Full option list in the [API Reference](/api-reference#options).
 
 ## TypeScript
 

--- a/packages/use-mask-input/package.json
+++ b/packages/use-mask-input/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "description": "Input masks for React and Vue 3. Works with React Hook Form, TanStack Form, vee-validate, and Ant Design.",
   "license": "MIT",
+  "homepage": "https://use-mask-input.eduardoborges.dev",
   "author": "Eduardo Borges<euduardoborges@gmail.com>",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Why

Cloudflare Web Analytics shows ~10 Google referrals in 30 days against 670 page views. Almost all traffic is internal navigation or direct. Auditing the site turned up four concrete defects.

## What was broken

**Trailing slash mismatch.** The sitemap listed `/intro`. Cloudflare Pages 308-redirects that to `/intro/`. The served page declared `/intro` as canonical. Every sitemap entry pointed crawlers at a redirect, landing on a page that pointed back at the redirect. Analytics confirms the split: `/api-reference` and `/api-reference/` were counted as separate pages.

**Meta descriptions.** No doc carried a `description`, so Docusaurus derived one from the first paragraph. On `/intro` the first paragraph is raw JSX, and the description shipped as `<div style={{`.

**Titles.** `/intro` was titled `use-mask-input`, the home page duplicated the site name.

**npm homepage.** The npm page ranks for input-mask searches and did not link here, because `homepage` was missing from `package.json`.

## What changed

| Fix | File |
|---|---|
| `trailingSlash: true` | `apps/docussaurus/docusaurus.config.ts` |
| `description` + `title` on all 13 docs, `sidebar_label` keeps the short name | `docs/**/*.md` |
| Home title no longer repeats the site name | `apps/docussaurus/src/pages/index.tsx` |
| `homepage` field | `packages/use-mask-input/package.json` |

Trailing slashes broke 12 relative links (`](./api-reference)` resolved to `/antd/api-reference/`), so those are now absolute. The build catches these via `onBrokenLinks: 'throw'`.

## Verified

```
sitemap:  /intro/        canonical: /intro/
/intro/   desc: "Add input masks to React and Vue 3 forms: CPF, phone, currency, date..."
title:    "use-mask-input — input masks for React and Vue 3 | use-mask-input"
home:     "Input masks for React and Vue 3 | use-mask-input"
```

Sidebar labels unchanged, one `<h1>` per page, `pnpm build --filter=docs` green.

## Not addressed

`/category/mask-types` is a 316-word generated stub still in the sitemap.

None of this creates demand. It removes the technical drag; the site still has no backlinks and competes with Maskito and IMask.